### PR TITLE
Removed generic constraint for context

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Creating a behavior is very simple:
 public Behavior MyBehaviorTest(int value1, int value2)
 {
     var input = new Input(value1, value2);
-    var behavior = new Behavior<Context,Input>(input);
+    var behavior = new Behavior<Input>(input);
 
     // Configure behavior here...
     
@@ -30,23 +30,21 @@ Behaviors are regular test methods that are decorated with the `[Behavior]` attr
 
 ## Context and Input
 
-`DrillSergeant` is built on top of [`xunit`](https://xunit.net/) and makes use of `[Theory]` based tests.  As a result behavior tests require both a context to hold state throughout the test and input to drive the test.  These are typically defined using the C# `record` type:
+`DrillSergeant` is built on top of [`xunit`](https://xunit.net/) and makes use of `[Theory]` based tests.  `DrillSergeant` will automatically create a local context for the behavior to execute in.  Context on the other hand must be defined and provited to the behavior.  These are typically defined using the C# `record` type:
 
 ```
-public class Context {};
 public record Input();
 ```
 
-Each step within a behavior can update its context, which is then fed into the next step.  It's recommended to use the C# `record` type for inputs and `class` for context.
+Each step within a behavior can update its context, which is then fed into the next step.  While not required, it's recommended to use the C# `record` type for input.
 
-### Configuring Input and Context
+### Configuring Input
 
-The only required parameter to a behavior is the `input` parameter, which must be a type of `TInput`.  Context on the other hand is optional and can be omitted.  If it is, then a new instance of `TContext` will be instantiated using its parameterless constructor.
+The only required parameter to a behavior is the `input` parameter, which must be a type of `TInput`.  Context on the other hand is automatically created and maintained by `DrillSergeant`.
 
 ```
 var input = new Input();
-var behavior1 = new Behavior<Context,Input>(input); // Creates context automatically.
-var behavior2 = new Behavior<Context,Input>(input, new Context()); // Manually specify context.
+var behavior = new Behavior<Input>(input);
 ```
 
 ## Configuring Steps
@@ -70,8 +68,8 @@ Inline steps are convenient when you need a one-off step that won't be reused in
 Lambda steps are ideal for situations where a step needs to be reused for multiple behaviors within a single class:
 
 ```
-public LambdaStep<Context,Input> MyStep =>
-    new GivenLambdaStep<Context,Input>()
+public LambdaStep<Input> MyStep =>
+    new GivenLambdaStep<Input>()
         .Named("My step")
         .Handle( (c,i) => {
             // Perform some action.
@@ -85,7 +83,7 @@ As you can see, the syntax is nearly identical to an inline step.  In fact, inli
 Class steps are the most flexible type of step and best used when a particular step needs to be reused between multiple features.  To create a class step, override the desired verb and fill in the step method:
 
 ```
-public class MyStep<Context,Input> : GivenStep<Context,Input>
+public class MyStep<Input> : GivenStep<Input>
 {
     public override void Given(Context context, Input input)
     {
@@ -94,10 +92,10 @@ public class MyStep<Context,Input> : GivenStep<Context,Input>
 }
 ```
 
-Unlike inline and lambda steps, class steps are convention based.  By default, The `GivenStep`, `WhenStep`, and `ThenStep` provide virtual methods for convenience, but it is not required to use them.  Internally, `DrillSergeant` will pick a matching verb method with the most parameters.  For example:
+Unlike inline and lambda steps, class steps are convention based.  By default.  For example:
 
 ```
-public class MyStep<Context,Input> : GivenStep<Context,Input>
+public class MyStep<Input> : GivenStep<Input>
 {
     // DrillSergeant will *not* excute this.
     public override void Given(Context context, Input input)

--- a/src/DrillSergeant/BaseStep.cs
+++ b/src/DrillSergeant/BaseStep.cs
@@ -83,15 +83,17 @@ public abstract class BaseStep : IStep
             return source;
         }
 
-        if (contextType.IsInterface == false)
+        if (contextType.IsPrimitive ||
+            contextType.IsArray ||
+            contextType == typeof(string))
         {
-            var serialized = JsonConvert.SerializeObject(source);
-            var converted = JsonConvert.DeserializeObject(serialized, contextType)!;
-
-            return converted;
+            throw new InvalidOperationException("Cannot cast context to a primitive type.");
         }
 
-        return source;
+        var serialized = JsonConvert.SerializeObject(source);
+        var converted = JsonConvert.DeserializeObject(serialized, contextType)!;
+
+        return converted;
     }
 
     internal static void UpdateContext(IDictionary<string, object?> context, object changedContext)

--- a/src/DrillSergeant/BaseStep.cs
+++ b/src/DrillSergeant/BaseStep.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
@@ -27,13 +29,20 @@ public abstract class BaseStep : IStep
 
     public virtual async Task Execute(object context, object input)
     {
-        var handler = this.PickHandler();
-        var parameters = this.ResolveParameters(context, input, handler.Method.GetParameters());
+        var handler = PickHandler();
+        var parameters = ResolveParameters(context, input, handler.Method.GetParameters());
+        var resolvedContext = parameters.FirstOrDefault() ?? context;
         dynamic result = handler.DynamicInvoke(parameters)!;
 
         if (IsAsync(handler.Method))
         {
             await result;
+        }
+
+        if (object.ReferenceEquals(context, resolvedContext) == false)
+        {
+            var unpacked = UnpackContext(resolvedContext);
+            UpdateContext(context, unpacked);
         }
     }
 
@@ -46,14 +55,9 @@ public abstract class BaseStep : IStep
         {
             if (index == 0)
             {
-                return context;
+                return CastContext((IDictionary<string, object>)context, parameter.ParameterType);
             }
 
-            //if (parameter.ParameterType == contextType ||
-            //    contextType.GetInterfaces().Contains(parameter.ParameterType))
-            //{
-            //    return context;
-            //}
             if (parameter.ParameterType == inputType ||
                 inputType.GetInterfaces().Contains(parameter.ParameterType))
             {
@@ -71,6 +75,45 @@ public abstract class BaseStep : IStep
     [ExcludeFromCodeCoverage]
     protected virtual void Dispose(bool disposing)
     {
+    }
+
+    internal static object CastContext(IDictionary<string, object> source, Type contextType)
+    {
+        if (contextType == typeof(object))
+        {
+            return source;
+        }
+
+        if (contextType.IsInterface == false)
+        {
+            var serialized = JsonConvert.SerializeObject(source);
+            var converted = JsonConvert.DeserializeObject(serialized, contextType)!;
+
+            return converted;
+        }
+
+        return source;
+    }
+
+    internal static IDictionary<string, object> UnpackContext(object context)
+    {
+        var result = new Dictionary<string, object>();
+        var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty;
+
+        foreach (var property in context.GetType().GetProperties(flags))
+        {
+            result.Add(property.Name, property.GetValue(context)!);
+        }
+
+        return result;
+    }
+
+    internal static void UpdateContext(object context, object changedContext)
+    {
+        foreach (var (k, v) in (IDictionary<string, object>)changedContext)
+        {
+            ((IDictionary<string, object>)context)[k] = v;
+        }
     }
 
     internal static bool IsAsync(MethodInfo method) =>

--- a/src/DrillSergeant/Behavior.cs
+++ b/src/DrillSergeant/Behavior.cs
@@ -14,7 +14,7 @@ public class Behavior<TInput> : IBehavior
         this.Context = new ExpandoObject();
     }
 
-    public dynamic Context { get; } = new ExpandoObject();
+    public IDictionary<string,object?> Context { get; } = new ExpandoObject();
 
     public object Input { get; }
 

--- a/src/DrillSergeant/Behavior.cs
+++ b/src/DrillSergeant/Behavior.cs
@@ -8,11 +8,7 @@ public class Behavior<TInput> : IBehavior
 {
     protected readonly List<IStep> steps = new();
 
-    public Behavior(TInput input)
-    {
-        this.Input = input!;
-        this.Context = new ExpandoObject();
-    }
+    public Behavior(TInput input) => this.Input = input!;
 
     public IDictionary<string,object?> Context { get; } = new ExpandoObject();
 

--- a/src/DrillSergeant/Behavior.cs
+++ b/src/DrillSergeant/Behavior.cs
@@ -1,17 +1,17 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Dynamic;
 
 namespace DrillSergeant;
 
-public class Behavior<TContext, TInput> : IBehavior
-    where TContext : class, new()
+public class Behavior<TInput> : IBehavior
 {
     protected readonly List<IStep> steps = new();
 
-    public Behavior(TInput input, TContext? context = null)
+    public Behavior(TInput input, object? context = null)
     {
         this.Input = input!;
-        this.Context = context ?? new TContext();
+        this.Context = context ?? new ExpandoObject();
     }
 
     public object Context { get; }
@@ -20,13 +20,13 @@ public class Behavior<TContext, TInput> : IBehavior
 
     public bool LogContext { get; private set; }
 
-    public Behavior<TContext, TInput> AddStep(IStep step)
+    public Behavior<TInput> AddStep(IStep step)
     {
         this.steps.Add(step);
         return this;
     }
 
-    public Behavior<TContext, TInput> EnableContextLogging()
+    public Behavior<TInput> EnableContextLogging()
     {
         this.LogContext = true;
         return this;

--- a/src/DrillSergeant/GWT/BehaviorExtensions.cs
+++ b/src/DrillSergeant/GWT/BehaviorExtensions.cs
@@ -16,17 +16,17 @@ public static class BehaviorExtensions
     public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Action<dynamic> step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Action<TInput> step) =>
-        behavior.Given(step.Method.Name, step);
-
     public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Action<dynamic, TInput> step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Func<Task> step) =>
-        behavior.Given(step.Method.Name, step);
+    public static Behavior<TInput> GivenAsync<TInput>(this Behavior<TInput> behavior, Func<Task> step) =>
+        behavior.GivenAsync(step.Method.Name, step);
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Func<TInput, Task> step) =>
-        behavior.Given(step.Method.Name, step);
+    public static Behavior<TInput> GivenAsync<TInput>(this Behavior<TInput> behavior, Func<dynamic, Task> step) =>
+        behavior.GivenAsync(step.Method.Name, step);
+
+    public static Behavior<TInput> GivenAsync<TInput>(this Behavior<TInput> behavior, Func<dynamic, TInput, Task> step) =>
+        behavior.GivenAsync(step.Method.Name, step);
 
     public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Delegate step)
     {
@@ -58,16 +58,6 @@ public static class BehaviorExtensions
         return behavior;
     }
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Action<TInput> step)
-    {
-        behavior.AddStep(
-            new LambdaGivenStep<TInput>()
-                .Named(name)
-                .Handle(step));
-
-        return behavior;
-    }
-
     public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic, TInput> step)
     {
         behavior.AddStep(
@@ -78,7 +68,7 @@ public static class BehaviorExtensions
         return behavior;
     }
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Func<Task> step)
+    public static Behavior<TInput> GivenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<Task> step)
     {
         behavior.AddStep(
             new LambdaGivenStep<TInput>()
@@ -88,7 +78,7 @@ public static class BehaviorExtensions
         return behavior;
     }
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, Task> step)
+    public static Behavior<TInput> GivenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, Task> step)
     {
         behavior.AddStep(
             new LambdaGivenStep<TInput>()
@@ -98,7 +88,7 @@ public static class BehaviorExtensions
         return behavior;
     }
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Func<TInput, Task> step)
+    public static Behavior<TInput> GivenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, TInput, Task> step)
     {
         behavior.AddStep(
             new LambdaGivenStep<TInput>()
@@ -119,7 +109,7 @@ public static class BehaviorExtensions
     #region When
 
     public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Delegate step) =>
-      behavior.When(step.Method.Name, step);
+        behavior.When(step.Method.Name, step);
 
     public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Action step) =>
         behavior.When(step.Method.Name, step);
@@ -127,17 +117,17 @@ public static class BehaviorExtensions
     public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Action<dynamic> step) =>
         behavior.When(step.Method.Name, step);
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Action<TInput> step) =>
-        behavior.When(step.Method.Name, step);
-
     public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Action<dynamic, TInput> step) =>
         behavior.When(step.Method.Name, step);
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Func<Task> step) =>
-        behavior.When(step.Method.Name, step);
+    public static Behavior<TInput> WhenAsync<TInput>(this Behavior<TInput> behavior, Func<Task> step) =>
+        behavior.WhenAsync(step.Method.Name, step);
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Func<TInput, Task> step) =>
-        behavior.When(step.Method.Name, step);
+    public static Behavior<TInput> WhenAsync<TInput>(this Behavior<TInput> behavior, Func<dynamic, Task> step) =>
+        behavior.WhenAsync(step.Method.Name, step);
+
+    public static Behavior<TInput> WhenAsync<TInput>(this Behavior<TInput> behavior, Func<dynamic, TInput, Task> step) =>
+        behavior.WhenAsync(step.Method.Name, step);
 
     public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Delegate step)
     {
@@ -169,7 +159,7 @@ public static class BehaviorExtensions
         return behavior;
     }
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Action<TInput> step)
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic, TInput> step)
     {
         behavior.AddStep(
             new LambdaWhenStep<TInput>()
@@ -179,7 +169,7 @@ public static class BehaviorExtensions
         return behavior;
     }
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Func<Task> step)
+    public static Behavior<TInput> WhenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<Task> step)
     {
         behavior.AddStep(
             new LambdaWhenStep<TInput>()
@@ -189,7 +179,7 @@ public static class BehaviorExtensions
         return behavior;
     }
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, Task> step)
+    public static Behavior<TInput> WhenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, Task> step)
     {
         behavior.AddStep(
             new LambdaWhenStep<TInput>()
@@ -199,7 +189,7 @@ public static class BehaviorExtensions
         return behavior;
     }
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Func<TInput, Task> step)
+    public static Behavior<TInput> WhenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, TInput, Task> step)
     {
         behavior.AddStep(
             new LambdaWhenStep<TInput>()
@@ -220,7 +210,7 @@ public static class BehaviorExtensions
     #region Then
 
     public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Delegate step) =>
-       behavior.Then(step.Method.Name, step);
+        behavior.Then(step.Method.Name, step);
 
     public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Action step) =>
         behavior.Then(step.Method.Name, step);
@@ -228,17 +218,17 @@ public static class BehaviorExtensions
     public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Action<dynamic> step) =>
         behavior.Then(step.Method.Name, step);
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Action<TInput> step) =>
-        behavior.Then(step.Method.Name, step);
-
     public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Action<dynamic, TInput> step) =>
         behavior.Then(step.Method.Name, step);
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Func<Task> step) =>
-        behavior.Then(step.Method.Name, step);
+    public static Behavior<TInput> ThenAsync<TInput>(this Behavior<TInput> behavior, Func<Task> step) =>
+        behavior.ThenAsync(step.Method.Name, step);
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Func<TInput, Task> step) =>
-        behavior.Then(step.Method.Name, step);
+    public static Behavior<TInput> ThenAsync<TInput>(this Behavior<TInput> behavior, Func<dynamic, Task> step) =>
+        behavior.ThenAsync(step.Method.Name, step);
+
+    public static Behavior<TInput> ThenAsync<TInput>(this Behavior<TInput> behavior, Func<dynamic, TInput, Task> step) =>
+        behavior.ThenAsync(step.Method.Name, step);
 
     public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Delegate step)
     {
@@ -270,7 +260,7 @@ public static class BehaviorExtensions
         return behavior;
     }
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Action<TInput> step)
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic, TInput> step)
     {
         behavior.AddStep(
             new LambdaThenStep<TInput>()
@@ -280,7 +270,7 @@ public static class BehaviorExtensions
         return behavior;
     }
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Func<Task> step)
+    public static Behavior<TInput> ThenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<Task> step)
     {
         behavior.AddStep(
             new LambdaThenStep<TInput>()
@@ -290,7 +280,7 @@ public static class BehaviorExtensions
         return behavior;
     }
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, Task> step)
+    public static Behavior<TInput> ThenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, Task> step)
     {
         behavior.AddStep(
             new LambdaThenStep<TInput>()
@@ -300,7 +290,7 @@ public static class BehaviorExtensions
         return behavior;
     }
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Func<TInput, Task> step)
+    public static Behavior<TInput> ThenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, TInput, Task> step)
     {
         behavior.AddStep(
             new LambdaThenStep<TInput>()

--- a/src/DrillSergeant/GWT/BehaviorExtensions.cs
+++ b/src/DrillSergeant/GWT/BehaviorExtensions.cs
@@ -7,113 +7,108 @@ public static class BehaviorExtensions
 {
     #region Given
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, Delegate step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Delegate step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, Action step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Action step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, Action<TContext> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Action<dynamic> step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, Action<TContext, TInput> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Action<TInput> step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, Func<Task> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Action<dynamic, TInput> step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, Func<TContext, Task> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Func<Task> step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, Func<TContext, TInput, Task> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Func<TInput, Task> step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Delegate step)
-    where TContext : class, new()
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Delegate step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TContext, TInput>()
+            new LambdaGivenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Action step)
-        where TContext : class, new()
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Action step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TContext, TInput>()
+            new LambdaGivenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Action<TContext> step)
-        where TContext : class, new()
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic> step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TContext, TInput>()
+            new LambdaGivenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Action<TContext, TInput> step)
-        where TContext : class, new()
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Action<TInput> step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TContext, TInput>()
+            new LambdaGivenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Func<Task> step)
-        where TContext : class, new()
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic, TInput> step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TContext, TInput>()
+            new LambdaGivenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Func<TContext, Task> step)
-        where TContext : class, new()
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Func<Task> step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TContext, TInput>()
+            new LambdaGivenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Func<TContext, TInput, Task> step)
-        where TContext : class, new()
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, Task> step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TContext, TInput>()
+            new LambdaGivenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Given<TContext, TInput>(this Behavior<TContext, TInput> behavior, IStep step)
-        where TContext : class, new()
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Func<TInput, Task> step)
+    {
+        behavior.AddStep(
+            new LambdaGivenStep<TInput>()
+                .Named(name)
+                .Handle(step));
+
+        return behavior;
+    }
+
+    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, IStep step)
     {
         behavior.AddStep(step);
         return behavior;
@@ -123,113 +118,98 @@ public static class BehaviorExtensions
 
     #region When
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, Delegate step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Delegate step) =>
+      behavior.When(step.Method.Name, step);
+
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Action step) =>
         behavior.When(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, Action step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Action<dynamic> step) =>
         behavior.When(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, Action<TContext> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Action<TInput> step) =>
         behavior.When(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, Action<TContext, TInput> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Action<dynamic, TInput> step) =>
         behavior.When(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, Func<Task> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Func<Task> step) =>
         behavior.When(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, Func<TContext, Task> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Func<TInput, Task> step) =>
         behavior.When(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, Func<TContext, TInput, Task> step)
-        where TContext : class, new() =>
-        behavior.When(step.Method.Name, step);
-
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Delegate step)
-    where TContext : class, new()
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Delegate step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TContext, TInput>()
+            new LambdaWhenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Action step)
-        where TContext : class, new()
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Action step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TContext, TInput>()
+            new LambdaWhenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Action<TContext> step)
-        where TContext : class, new()
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic> step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TContext, TInput>()
+            new LambdaWhenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Action<TContext, TInput> step)
-        where TContext : class, new()
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Action<TInput> step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TContext, TInput>()
+            new LambdaWhenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Func<Task> step)
-        where TContext : class, new()
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Func<Task> step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TContext, TInput>()
+            new LambdaWhenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Func<TContext, Task> step)
-        where TContext : class, new()
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, Task> step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TContext, TInput>()
+            new LambdaWhenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Func<TContext, TInput, Task> step)
-        where TContext : class, new()
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Func<TInput, Task> step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TContext, TInput>()
+            new LambdaWhenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> When<TContext, TInput>(this Behavior<TContext, TInput> behavior, IStep step)
-        where TContext : class, new()
+    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, IStep step)
     {
         behavior.AddStep(step);
         return behavior;
@@ -239,113 +219,98 @@ public static class BehaviorExtensions
 
     #region Then
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, Delegate step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Delegate step) =>
+       behavior.Then(step.Method.Name, step);
+
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Action step) =>
         behavior.Then(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, Action step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Action<dynamic> step) =>
         behavior.Then(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, Action<TContext> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Action<TInput> step) =>
         behavior.Then(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, Action<TContext, TInput> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Action<dynamic, TInput> step) =>
         behavior.Then(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, Func<Task> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Func<Task> step) =>
         behavior.Then(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, Func<TContext, Task> step)
-        where TContext : class, new() =>
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Func<TInput, Task> step) =>
         behavior.Then(step.Method.Name, step);
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, Func<TContext, TInput, Task> step)
-        where TContext : class, new() =>
-        behavior.Then(step.Method.Name, step);
-
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Delegate step)
-    where TContext : class, new()
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Delegate step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TContext, TInput>()
+            new LambdaThenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Action step)
-        where TContext : class, new()
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Action step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TContext, TInput>()
+            new LambdaThenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Action<TContext> step)
-        where TContext : class, new()
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic> step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TContext, TInput>()
+            new LambdaThenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Action<TContext, TInput> step)
-        where TContext : class, new()
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Action<TInput> step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TContext, TInput>()
+            new LambdaThenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Func<Task> step)
-        where TContext : class, new()
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Func<Task> step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TContext, TInput>()
+            new LambdaThenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Func<TContext, Task> step)
-        where TContext : class, new()
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, Task> step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TContext, TInput>()
+            new LambdaThenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, string name, Func<TContext, TInput, Task> step)
-        where TContext : class, new()
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Func<TInput, Task> step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TContext, TInput>()
+            new LambdaThenStep<TInput>()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TContext, TInput> Then<TContext, TInput>(this Behavior<TContext, TInput> behavior, IStep step)
-        where TContext : class, new()
+    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, IStep step)
     {
         behavior.AddStep(step);
         return behavior;

--- a/src/DrillSergeant/GWT/GivenStep.cs
+++ b/src/DrillSergeant/GWT/GivenStep.cs
@@ -1,13 +1,9 @@
 ﻿namespace DrillSergeant.GWT;
 
-public class GivenStep<TContext, TInput> : VerbStep<TContext, TInput>
+public class GivenStep<TInput> : VerbStep<TInput>
 {
     public GivenStep()
         : base("Given")
-    {
-    }
-
-    public virtual void Given(TContext context, TInput input)
     {
     }
 }

--- a/src/DrillSergeant/GWT/LambdaGivenStep.cs
+++ b/src/DrillSergeant/GWT/LambdaGivenStep.cs
@@ -1,6 +1,6 @@
 ﻿namespace DrillSergeant.GWT;
 
-public class LambdaGivenStep<TContext, TInput> : LambdaStep<TContext, TInput>
+public class LambdaGivenStep< TInput> : LambdaStep<TInput>
 {
     public LambdaGivenStep()
         : base("Given")

--- a/src/DrillSergeant/GWT/LambdaThenStep.cs
+++ b/src/DrillSergeant/GWT/LambdaThenStep.cs
@@ -1,6 +1,6 @@
 ﻿namespace DrillSergeant.GWT;
 
-public class LambdaThenStep<TContext, TInput> : LambdaStep<TContext, TInput>
+public class LambdaThenStep<TInput> : LambdaStep<TInput>
 {
     public LambdaThenStep()
         : base("Then")

--- a/src/DrillSergeant/GWT/LambdaWhenStep.cs
+++ b/src/DrillSergeant/GWT/LambdaWhenStep.cs
@@ -1,6 +1,6 @@
 ﻿namespace DrillSergeant.GWT;
 
-public class LambdaWhenStep<TContext, TInput> : LambdaStep<TContext, TInput>
+public class LambdaWhenStep<TInput> : LambdaStep<TInput>
 {
     public LambdaWhenStep()
         : base("When")

--- a/src/DrillSergeant/GWT/ThenStep.cs
+++ b/src/DrillSergeant/GWT/ThenStep.cs
@@ -1,11 +1,9 @@
 ﻿namespace DrillSergeant.GWT;
 
-public class ThenStep<TContext, TInput> : VerbStep<TContext, TInput>
+public class ThenStep<TInput> : VerbStep<TInput>
 {
     public ThenStep()
         : base("Then")
     {
     }
-
-    public virtual void Then(TContext context, TInput input) { }
 }

--- a/src/DrillSergeant/GWT/WhenStep.cs
+++ b/src/DrillSergeant/GWT/WhenStep.cs
@@ -1,13 +1,9 @@
 ﻿namespace DrillSergeant.GWT;
 
-public class WhenStep<TContext, TInput> : VerbStep<TContext, TInput>
+public class WhenStep<TInput> : VerbStep<TInput>
 {
     public WhenStep()
         : base("When")
-    {
-    }
-
-    public virtual void When(TContext context, TInput input)
     {
     }
 }

--- a/src/DrillSergeant/IBehavior.cs
+++ b/src/DrillSergeant/IBehavior.cs
@@ -4,7 +4,7 @@ namespace DrillSergeant;
 
 public interface IBehavior : IEnumerable<IStep>
 {
-    object Context { get; }
+    IDictionary<string,object?> Context { get; }
     object Input { get; }
     bool LogContext { get; }
 }

--- a/src/DrillSergeant/IStep.cs
+++ b/src/DrillSergeant/IStep.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace DrillSergeant;
@@ -9,5 +10,5 @@ public interface IStep : IDisposable
     
     string Name { get; }
 
-    Task Execute(object context, object input);
+    Task Execute(IDictionary<string,object?> context, object input);
 }

--- a/src/DrillSergeant/LambdaStep.cs
+++ b/src/DrillSergeant/LambdaStep.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace DrillSergeant;
 
-public class LambdaStep<TContext, TInput> : BaseStep
+public class LambdaStep<TInput> : BaseStep
 {
     private string? name;
     private Delegate handler = () => { };
@@ -13,9 +13,9 @@ public class LambdaStep<TContext, TInput> : BaseStep
         this.Verb = verb;
     }
 
-    public override string Name => this.name ?? this.handler?.Method?.GetType().FullName ?? nameof(LambdaStep<TContext, TInput>);
+    public override string Name => this.name ?? this.handler?.Method?.GetType().FullName ?? nameof(LambdaStep<TInput>);
 
-    public LambdaStep<TContext, TInput> Named(string name)
+    public LambdaStep<TInput> Named(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
@@ -26,7 +26,7 @@ public class LambdaStep<TContext, TInput> : BaseStep
         return this;
     }
 
-    private LambdaStep<TContext, TInput> SetHandler(Delegate? handler)
+    private LambdaStep<TInput> SetHandler(Delegate? handler)
     {
         if (handler != null)
         {
@@ -36,15 +36,15 @@ public class LambdaStep<TContext, TInput> : BaseStep
         return this;
     }
 
-    public LambdaStep<TContext, TInput> Handle(Delegate handler) => this.SetHandler(handler);
+    public LambdaStep<TInput> Handle(Delegate handler) => this.SetHandler(handler);
 
-    public LambdaStep<TContext, TInput> Handle(Action? handler) => this.SetHandler(handler);
-    public LambdaStep<TContext, TInput> Handle(Action<TContext>? handler) => this.SetHandler(handler);
-    public LambdaStep<TContext, TInput> Handle(Action<TContext, TInput>? handler) => this.SetHandler(handler);
+    public LambdaStep<TInput> Handle(Action? handler) => this.SetHandler(handler);
+    public LambdaStep<TInput> Handle(Action<dynamic>? handler) => this.SetHandler(handler);
+    public LambdaStep<TInput> Handle(Action<dynamic, TInput>? handler) => this.SetHandler(handler);
 
-    public LambdaStep<TContext, TInput> Handle(Func<Task>? handler) => this.SetHandler(handler);
-    public LambdaStep<TContext, TInput> Handle(Func<TContext, Task>? handler) => this.SetHandler(handler);
-    public LambdaStep<TContext, TInput> Handle(Func<TContext, TInput, Task>? handler) => this.SetHandler(handler);
+    public LambdaStep<TInput> Handle(Func<Task>? handler) => this.SetHandler(handler);
+    public LambdaStep<TInput> Handle(Func<dynamic, Task>? handler) => this.SetHandler(handler);
+    public LambdaStep<TInput> Handle(Func<dynamic, TInput, Task>? handler) => this.SetHandler(handler);
 
     public override async Task Execute(object context, object input)
     {

--- a/src/DrillSergeant/VerbStep.cs
+++ b/src/DrillSergeant/VerbStep.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace DrillSergeant;
 
-public class VerbStep<TContext, TInput> : BaseStep
+public class VerbStep<TInput> : BaseStep
 {
     public record VerbMethod(MethodInfo Method, object Target, bool IsAsync);
 

--- a/test/DrillSergeant.Tests/BaseStepTests.cs
+++ b/test/DrillSergeant.Tests/BaseStepTests.cs
@@ -1,6 +1,7 @@
 ﻿using FakeItEasy;
 using Shouldly;
 using System;
+using System.Dynamic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -41,33 +42,16 @@ public class BaseStepTests
         private readonly MethodInfo stubExecuteMethodWithParameters = GetMethod(typeof(ResolveParametersMethod), nameof(StubExecuteMethodWithParameters));
 
         [Fact]
-        public void ContextParameterResolvesToPassedContext()
-        {
-            // Arrange.
-            var step = A.Fake<BaseStep>(options => options.CallsBaseMethods());
-            var context = new Context();
-            var input = new Input();
-            var parameters = stubExecuteMethodWithParameters.GetParameters();
-
-            // Act.
-            var resolvedParameters = step.ResolveParameters(context, input, parameters);
-            var resolvedContext = resolvedParameters.First(x => x!.GetType() == typeof(Context));
-
-            // Assert.
-            resolvedContext.ShouldBeSameAs(context);
-        }
-
-        [Fact]
         public void InputParameterResolvesToPassedInput()
         {
             // Arrange.
             var step = A.Fake<BaseStep>(options => options.CallsBaseMethods());
-            var context = new Context();
+            dynamic context = new ExpandoObject();
             var input = new Input();
             var parameters = stubExecuteMethodWithParameters.GetParameters();
 
             // Act.
-            var resolvedParameters = step.ResolveParameters(context, input, parameters);
+            var resolvedParameters = (object?[])step.ResolveParameters(context, input, parameters);
             var resolvedInput = resolvedParameters.First(x => x!.GetType() == typeof(Input));
 
             // Assert.

--- a/test/DrillSergeant.Tests/Features/CalculatorFeature.cs
+++ b/test/DrillSergeant.Tests/Features/CalculatorFeature.cs
@@ -35,7 +35,7 @@ public class CalculatorBehaviors
     {
         var input = new Input(a, b, a + b);
 
-        return new Behavior<Context, Input>(input)
+        return new Behavior<Input>(input)
             .EnableContextLogging()
             .Given("Set first number", (c, i) => c.A = i.A) // Inline step declaration.
             .Given(SetSecondNumber)
@@ -44,9 +44,9 @@ public class CalculatorBehaviors
     }
 
     [Behavior, MemberData(nameof(AdditionInputs))]
-    public Task<Behavior<Context,Input>> AsyncAdditionBehavior(int a, int b, int expected)
+    public Task<Behavior<Input>> AsyncAdditionBehavior(int a, int b, int expected)
     {
-        var behavior = new Behavior<Context, Input>(new Input(a, b, expected))
+        var behavior = new Behavior<Input>(new Input(a, b, expected))
             .Given("Set first number", (c, i) => c.A = i.A)
             .Given(SetSecondNumberAsync)
             .When(AddNumbersAsync(calculator))
@@ -60,7 +60,7 @@ public class CalculatorBehaviors
     {
         var input = new Input(a, b, expected);
 
-        return new Behavior<Context, Input>(input)
+        return new Behavior<Input>(input)
             .EnableContextLogging()
             .Given("Set first number", (c, i) => c.A = i.A) // Inline step declaration.
             .Given(SetSecondNumber)
@@ -78,16 +78,16 @@ public class CalculatorBehaviors
     }
 
     // Step implemented as a lambda step for greater flexibility.
-    public LambdaStep<Context, Input> AddNumbers(Calculator calculator) =>
-        new LambdaWhenStep<Context, Input>()
+    public LambdaStep<Input> AddNumbers(Calculator calculator) =>
+        new LambdaWhenStep<Input>()
             .Named("Add numbers")
             .Handle((c) =>
             {
                 c.Result = calculator.Add(c.A, c.B);
             });
 
-    public LambdaStep<Context, Input> AddNumbersAsync(Calculator calculator) =>
-        new LambdaWhenStep<Context, Input>()
+    public LambdaStep<Input> AddNumbersAsync(Calculator calculator) =>
+        new LambdaWhenStep<Input>()
             .Named("Add numbers")
             .Handle((c, _) =>
             {
@@ -96,18 +96,18 @@ public class CalculatorBehaviors
             });
 
     // Step implemented as type for full customization and reusability.
-    public class CheckResultStep : ThenStep<Context, Input>
+    public class CheckResultStep : ThenStep<Input>
     {
-        public override void Then(Context context, Input input)
+        public void Then(dynamic context, Input input)
         {
             Assert.Equal(input.Expected, context.Result);
         }
     }
 
     // Class-level step.
-    public class CheckResultStepAsync : ThenStep<Context, Input>
+    public class CheckResultStepAsync : ThenStep<Input>
     {
-        public Task ThenAsync(Context context, Input input)
+        public Task ThenAsync(dynamic context, Input input)
         {
             Assert.Equal(input.Expected, context.Result);
             return Task.CompletedTask;

--- a/test/DrillSergeant.Tests/Features/CalculatorFeature.cs
+++ b/test/DrillSergeant.Tests/Features/CalculatorFeature.cs
@@ -41,7 +41,7 @@ public class CalculatorBehaviors
     {
         var behavior = new Behavior<Input>(new Input(a, b, expected))
             .Given("Set first number", (c, i) => c.A = i.A)
-            .Given(SetSecondNumberAsync)
+            .GivenAsync(SetSecondNumberAsync)
             .When(AddNumbersAsync(calculator))
             .Then(new CheckResultStepAsync());
 

--- a/test/DrillSergeant.Tests/Features/CalculatorFeature.cs
+++ b/test/DrillSergeant.Tests/Features/CalculatorFeature.cs
@@ -10,13 +10,6 @@ public class CalculatorBehaviors
 {
     private readonly Calculator calculator = new();
 
-    public class Context
-    {
-        public int A { get; set; }
-        public int B { get; set; }
-        public int Result { get; set; }
-    }
-
     public record Input(int A, int B, int Expected);
 
     public static IEnumerable<object[]> AdditionInputs
@@ -69,9 +62,9 @@ public class CalculatorBehaviors
     }
 
     // Step implemented as a normal method.
-    private void SetSecondNumber(Context context, Input input) => context.B = input.B;
+    private void SetSecondNumber(dynamic context, Input input) => context.B = input.B;
 
-    private Task SetSecondNumberAsync(Context context, Input input)
+    private Task SetSecondNumberAsync(dynamic context, Input input)
     {
         context.B = input.B;
         return Task.CompletedTask;

--- a/test/DrillSergeant.Tests/LambdaStepTests.cs
+++ b/test/DrillSergeant.Tests/LambdaStepTests.cs
@@ -20,7 +20,7 @@ public class LambdaStepTests
         public void SettingBlankNameDoesNotChangeExistingValue(string blankValue)
         {
             // Arrange.
-            var step = new LambdaStep<Context, Input>("Test").Named("expected");
+            var step = new LambdaStep<Input>("Test").Named("expected");
 
             // Act.
             step.Named(blankValue);
@@ -43,7 +43,7 @@ public class LambdaStepTests
         public async Task NonAsyncHandlerWithReturnReturnsValue()
         {
             // Arrange.
-            var step = new LambdaStep<Context, Input>("Test").Handle((c, i) => c.Value = 1);
+            var step = new LambdaStep<Input>("Test").Handle((c, i) => c.Value = 1);
             var context = new Context();
             var input = new Input();
 
@@ -58,7 +58,7 @@ public class LambdaStepTests
         public async Task AsyncHandlerWithReturnReturnsValue()
         {
             // Arrange.
-            var step = new LambdaStep<Context, Input>("Test").Handle((c, i) =>
+            var step = new LambdaStep<Input>("Test").Handle((c, i) =>
             {
                 c.Value = 1;
                 return Task.CompletedTask;

--- a/test/DrillSergeant.Tests/VerbStepTests.cs
+++ b/test/DrillSergeant.Tests/VerbStepTests.cs
@@ -1,5 +1,6 @@
 ﻿using Shouldly;
 using System;
+using System.Dynamic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -57,7 +58,7 @@ public class VerbStepTests
 
     public class ExecuteMethod : VerbStepTests
     {
-        public record Context
+        public class Context
         {
             public int Value { get; set; }
         }
@@ -69,14 +70,14 @@ public class VerbStepTests
         {
             // Arrange.
             var step = new StubStep_NonAsync_ReturnsValue();
-            var context = new Context();
+            dynamic context = new ExpandoObject();
             var input = new Input();
 
             // Act.
             await step.Execute(context, input);
 
             // Assert.
-            context.Value.ShouldBe(1);
+            Assert.Equal(1, context.Value);
         }
 
         [Fact]
@@ -84,14 +85,14 @@ public class VerbStepTests
         {
             // Arrange.
             var step = new StubStep_Async_ReturnsValue();
-            var context = new Context();
+            dynamic context = new ExpandoObject();
             var input = new Input();
 
             // Act.
             await step.Execute(context, input);
 
             // Assert.
-            context.Value.ShouldBe(1);
+            Assert.Equal(1, context.Value);
         }
 
         public class StubStep_NonAsync_ReturnsValue : VerbStep<Input>

--- a/test/DrillSergeant.Tests/VerbStepTests.cs
+++ b/test/DrillSergeant.Tests/VerbStepTests.cs
@@ -42,7 +42,7 @@ public class VerbStepTests
             Assert.Equal(typeof(StubStep).Name, step.Name);
         }
 
-        public class StubStep : VerbStep<object,object>
+        public class StubStep : VerbStep<object>
         {
             public StubStep(string verb) : base(verb)
             {
@@ -94,7 +94,7 @@ public class VerbStepTests
             context.Value.ShouldBe(1);
         }
 
-        public class StubStep_NonAsync_ReturnsValue : VerbStep<Context, Input>
+        public class StubStep_NonAsync_ReturnsValue : VerbStep<Input>
         {
             public StubStep_NonAsync_ReturnsValue() : base("Test")
             {
@@ -103,7 +103,7 @@ public class VerbStepTests
             public void Test(Context context, Input input) => context.Value = 1;
         }
 
-        public class StubStep_Async_ReturnsValue : VerbStep<Context, Input>
+        public class StubStep_Async_ReturnsValue : VerbStep<Input>
         {
             public StubStep_Async_ReturnsValue() : base("Test")
             {
@@ -121,7 +121,7 @@ public class VerbStepTests
             void DoSomething();
         }
 
-        public class StubWithNoParameters : VerbStep<Context,Input>
+        public class StubWithNoParameters : VerbStep<Input>
         {
             public StubWithNoParameters()
                 : base("Test")
@@ -136,7 +136,7 @@ public class VerbStepTests
             }
         }
 
-        public class StubWithInjectableParameter : VerbStep<Context, Input>
+        public class StubWithInjectableParameter : VerbStep<Input>
         {
             public StubWithInjectableParameter()
                 : base("Test")
@@ -149,7 +149,7 @@ public class VerbStepTests
             }
         }
 
-        public class StubThatReturnsValue_Sync : VerbStep<Context, Input>
+        public class StubThatReturnsValue_Sync : VerbStep<Input>
         {
             public StubThatReturnsValue_Sync()
                 : base("Test")
@@ -159,7 +159,7 @@ public class VerbStepTests
             public string Test() => "expected";
         }
 
-        public class StubThatReturnsValue_Async : VerbStep<Context, Input>
+        public class StubThatReturnsValue_Async : VerbStep<Input>
         {
             public StubThatReturnsValue_Async()
                 : base("Test")
@@ -231,13 +231,13 @@ public class VerbStepTests
         public void ThrowsAmbiguousVerbException_Scenarios(Type type)
         {
             // Arrange.
-            var stub = (VerbStep<object, object>)Activator.CreateInstance(type)!;
+            var stub = (VerbStep<object>)Activator.CreateInstance(type)!;
 
             // Assert.
             Assert.Throws<AmbiguousVerbException>(() => stub.PickHandler());
         }
 
-        public class StubWithMultipleSyncVerbs : VerbStep<object, object>
+        public class StubWithMultipleSyncVerbs : VerbStep<object>
         {
             public StubWithMultipleSyncVerbs()
                 : base("Test")
@@ -248,7 +248,7 @@ public class VerbStepTests
             public void Test(int arg1) { }
         }
 
-        public class StubWithSyncAndAsync_SameName : VerbStep<object, object>
+        public class StubWithSyncAndAsync_SameName : VerbStep<object>
         {
             public StubWithSyncAndAsync_SameName()
                 : base("Test")
@@ -259,7 +259,7 @@ public class VerbStepTests
             public Task Test(string arg) => Task.CompletedTask;
         }
 
-        public class StubWithSyncAndAsync_DifferentName : VerbStep<object, object>
+        public class StubWithSyncAndAsync_DifferentName : VerbStep<object>
         {
             public StubWithSyncAndAsync_DifferentName()
                 : base("Test")
@@ -270,7 +270,7 @@ public class VerbStepTests
             public Task TestAsync(int arg) => Task.CompletedTask;
         }
 
-        public class StubWithNoVerb : VerbStep<object, object>
+        public class StubWithNoVerb : VerbStep<object>
         {
             public StubWithNoVerb()
                 : base("ignored")
@@ -278,7 +278,7 @@ public class VerbStepTests
             }
         }
 
-        public class StubWithTwoHandlersSameNumberOfParameters_NoAsync : VerbStep<object, object>
+        public class StubWithTwoHandlersSameNumberOfParameters_NoAsync : VerbStep<object>
         {
             public StubWithTwoHandlersSameNumberOfParameters_NoAsync()
                 : base("Test")
@@ -290,7 +290,7 @@ public class VerbStepTests
             public void Test(string arg) { }
         }
 
-        public class StubWithTwoHandlers_SameNumberOfParameters_TwoAsync : VerbStep<object, object>
+        public class StubWithTwoHandlers_SameNumberOfParameters_TwoAsync : VerbStep<object>
         {
             public StubWithTwoHandlers_SameNumberOfParameters_TwoAsync()
                 : base("Test")


### PR DESCRIPTION
Converted context from a generic constraint to a `dynamic`.  Step executor will now convert between `dynamic` and type-safe context parameter on demand.