### PR TITLE
Behavior inputs are no longer bound to generics

### DIFF
--- a/src/DrillSergeant/Behavior.cs
+++ b/src/DrillSergeant/Behavior.cs
@@ -1,28 +1,41 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Reflection;
 
 namespace DrillSergeant;
 
-public class Behavior<TInput> : IBehavior
+public class Behavior : IBehavior
 {
     protected readonly List<IStep> steps = new();
 
-    public Behavior(TInput input) => this.Input = input!;
+    public Behavior(object input)
+    {
+        var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty;
+        dynamic castedInput = new ExpandoObject();
+        var dict = (IDictionary<string, object?>)castedInput;
+
+        foreach(var property in input.GetType().GetProperties(flags))
+        {
+            dict[property.Name] = property.GetValue(input);
+        }
+
+        this.Input = dict;
+    }
 
     public IDictionary<string,object?> Context { get; } = new ExpandoObject();
 
-    public object Input { get; }
+    public IDictionary<string, object?> Input { get; }
 
     public bool LogContext { get; private set; }
 
-    public Behavior<TInput> AddStep(IStep step)
+    public Behavior AddStep(IStep step)
     {
         this.steps.Add(step);
         return this;
     }
 
-    public Behavior<TInput> EnableContextLogging()
+    public Behavior EnableContextLogging()
     {
         this.LogContext = true;
         return this;

--- a/src/DrillSergeant/GWT/BehaviorExtensions.cs
+++ b/src/DrillSergeant/GWT/BehaviorExtensions.cs
@@ -7,98 +7,98 @@ public static class BehaviorExtensions
 {
     #region Given
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Delegate step) =>
+    public static Behavior Given(this Behavior behavior, Delegate step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Action step) =>
+    public static Behavior Given(this Behavior behavior, Action step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Action<dynamic> step) =>
+    public static Behavior Given(this Behavior behavior, Action<dynamic> step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, Action<dynamic, TInput> step) =>
+    public static Behavior Given(this Behavior behavior, Action<dynamic, dynamic> step) =>
         behavior.Given(step.Method.Name, step);
 
-    public static Behavior<TInput> GivenAsync<TInput>(this Behavior<TInput> behavior, Func<Task> step) =>
+    public static Behavior GivenAsync(this Behavior behavior, Func<Task> step) =>
         behavior.GivenAsync(step.Method.Name, step);
 
-    public static Behavior<TInput> GivenAsync<TInput>(this Behavior<TInput> behavior, Func<dynamic, Task> step) =>
+    public static Behavior GivenAsync(this Behavior behavior, Func<dynamic, Task> step) =>
         behavior.GivenAsync(step.Method.Name, step);
 
-    public static Behavior<TInput> GivenAsync<TInput>(this Behavior<TInput> behavior, Func<dynamic, TInput, Task> step) =>
+    public static Behavior GivenAsync(this Behavior behavior, Func<dynamic, dynamic, Task> step) =>
         behavior.GivenAsync(step.Method.Name, step);
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Delegate step)
+    public static Behavior Given(this Behavior behavior, string name, Delegate step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TInput>()
+            new LambdaGivenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Action step)
+    public static Behavior Given(this Behavior behavior, string name, Action step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TInput>()
+            new LambdaGivenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic> step)
+    public static Behavior Given(this Behavior behavior, string name, Action<dynamic> step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TInput>()
+            new LambdaGivenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic, TInput> step)
+    public static Behavior Given(this Behavior behavior, string name, Action<dynamic, dynamic> step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TInput>()
+            new LambdaGivenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> GivenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<Task> step)
+    public static Behavior GivenAsync(this Behavior behavior, string name, Func<Task> step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TInput>()
+            new LambdaGivenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> GivenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, Task> step)
+    public static Behavior GivenAsync(this Behavior behavior, string name, Func<dynamic, Task> step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TInput>()
+            new LambdaGivenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> GivenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, TInput, Task> step)
+    public static Behavior GivenAsync(this Behavior behavior, string name, Func<dynamic, dynamic, Task> step)
     {
         behavior.AddStep(
-            new LambdaGivenStep<TInput>()
+            new LambdaGivenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> Given<TInput>(this Behavior<TInput> behavior, IStep step)
+    public static Behavior Given(this Behavior behavior, IStep step)
     {
         behavior.AddStep(step);
         return behavior;
@@ -108,98 +108,98 @@ public static class BehaviorExtensions
 
     #region When
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Delegate step) =>
+    public static Behavior When(this Behavior behavior, Delegate step) =>
         behavior.When(step.Method.Name, step);
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Action step) =>
+    public static Behavior When(this Behavior behavior, Action step) =>
         behavior.When(step.Method.Name, step);
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Action<dynamic> step) =>
+    public static Behavior When(this Behavior behavior, Action<dynamic> step) =>
         behavior.When(step.Method.Name, step);
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, Action<dynamic, TInput> step) =>
+    public static Behavior When(this Behavior behavior, Action<dynamic, dynamic> step) =>
         behavior.When(step.Method.Name, step);
 
-    public static Behavior<TInput> WhenAsync<TInput>(this Behavior<TInput> behavior, Func<Task> step) =>
+    public static Behavior WhenAsync(this Behavior behavior, Func<Task> step) =>
         behavior.WhenAsync(step.Method.Name, step);
 
-    public static Behavior<TInput> WhenAsync<TInput>(this Behavior<TInput> behavior, Func<dynamic, Task> step) =>
+    public static Behavior WhenAsync(this Behavior behavior, Func<dynamic, Task> step) =>
         behavior.WhenAsync(step.Method.Name, step);
 
-    public static Behavior<TInput> WhenAsync<TInput>(this Behavior<TInput> behavior, Func<dynamic, TInput, Task> step) =>
+    public static Behavior WhenAsync(this Behavior behavior, Func<dynamic, dynamic, Task> step) =>
         behavior.WhenAsync(step.Method.Name, step);
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Delegate step)
+    public static Behavior When(this Behavior behavior, string name, Delegate step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TInput>()
+            new LambdaWhenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Action step)
+    public static Behavior When(this Behavior behavior, string name, Action step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TInput>()
+            new LambdaWhenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic> step)
+    public static Behavior When(this Behavior behavior, string name, Action<dynamic> step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TInput>()
+            new LambdaWhenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic, TInput> step)
+    public static Behavior When(this Behavior behavior, string name, Action<dynamic, dynamic> step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TInput>()
+            new LambdaWhenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> WhenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<Task> step)
+    public static Behavior WhenAsync(this Behavior behavior, string name, Func<Task> step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TInput>()
+            new LambdaWhenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> WhenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, Task> step)
+    public static Behavior WhenAsync(this Behavior behavior, string name, Func<dynamic, Task> step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TInput>()
+            new LambdaWhenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> WhenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, TInput, Task> step)
+    public static Behavior WhenAsync(this Behavior behavior, string name, Func<dynamic, dynamic, Task> step)
     {
         behavior.AddStep(
-            new LambdaWhenStep<TInput>()
+            new LambdaWhenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> When<TInput>(this Behavior<TInput> behavior, IStep step)
+    public static Behavior When(this Behavior behavior, IStep step)
     {
         behavior.AddStep(step);
         return behavior;
@@ -209,98 +209,98 @@ public static class BehaviorExtensions
 
     #region Then
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Delegate step) =>
+    public static Behavior Then(this Behavior behavior, Delegate step) =>
         behavior.Then(step.Method.Name, step);
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Action step) =>
+    public static Behavior Then(this Behavior behavior, Action step) =>
         behavior.Then(step.Method.Name, step);
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Action<dynamic> step) =>
+    public static Behavior Then(this Behavior behavior, Action<dynamic> step) =>
         behavior.Then(step.Method.Name, step);
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, Action<dynamic, TInput> step) =>
+    public static Behavior Then(this Behavior behavior, Action<dynamic, dynamic> step) =>
         behavior.Then(step.Method.Name, step);
 
-    public static Behavior<TInput> ThenAsync<TInput>(this Behavior<TInput> behavior, Func<Task> step) =>
+    public static Behavior ThenAsync(this Behavior behavior, Func<Task> step) =>
         behavior.ThenAsync(step.Method.Name, step);
 
-    public static Behavior<TInput> ThenAsync<TInput>(this Behavior<TInput> behavior, Func<dynamic, Task> step) =>
+    public static Behavior ThenAsync(this Behavior behavior, Func<dynamic, Task> step) =>
         behavior.ThenAsync(step.Method.Name, step);
 
-    public static Behavior<TInput> ThenAsync<TInput>(this Behavior<TInput> behavior, Func<dynamic, TInput, Task> step) =>
+    public static Behavior ThenAsync(this Behavior behavior, Func<dynamic, dynamic, Task> step) =>
         behavior.ThenAsync(step.Method.Name, step);
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Delegate step)
+    public static Behavior Then(this Behavior behavior, string name, Delegate step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TInput>()
+            new LambdaThenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Action step)
+    public static Behavior Then(this Behavior behavior, string name, Action step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TInput>()
+            new LambdaThenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic> step)
+    public static Behavior Then(this Behavior behavior, string name, Action<dynamic> step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TInput>()
+            new LambdaThenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, string name, Action<dynamic, TInput> step)
+    public static Behavior Then(this Behavior behavior, string name, Action<dynamic, dynamic> step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TInput>()
+            new LambdaThenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> ThenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<Task> step)
+    public static Behavior ThenAsync(this Behavior behavior, string name, Func<Task> step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TInput>()
+            new LambdaThenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> ThenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, Task> step)
+    public static Behavior ThenAsync(this Behavior behavior, string name, Func<dynamic, Task> step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TInput>()
+            new LambdaThenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> ThenAsync<TInput>(this Behavior<TInput> behavior, string name, Func<dynamic, TInput, Task> step)
+    public static Behavior ThenAsync(this Behavior behavior, string name, Func<dynamic, dynamic, Task> step)
     {
         behavior.AddStep(
-            new LambdaThenStep<TInput>()
+            new LambdaThenStep()
                 .Named(name)
                 .Handle(step));
 
         return behavior;
     }
 
-    public static Behavior<TInput> Then<TInput>(this Behavior<TInput> behavior, IStep step)
+    public static Behavior Then(this Behavior behavior, IStep step)
     {
         behavior.AddStep(step);
         return behavior;

--- a/src/DrillSergeant/GWT/GivenStep.cs
+++ b/src/DrillSergeant/GWT/GivenStep.cs
@@ -1,6 +1,6 @@
 ﻿namespace DrillSergeant.GWT;
 
-public class GivenStep<TInput> : VerbStep<TInput>
+public class GivenStep : VerbStep
 {
     public GivenStep()
         : base("Given")

--- a/src/DrillSergeant/GWT/LambdaGivenStep.cs
+++ b/src/DrillSergeant/GWT/LambdaGivenStep.cs
@@ -1,6 +1,6 @@
 ﻿namespace DrillSergeant.GWT;
 
-public class LambdaGivenStep< TInput> : LambdaStep<TInput>
+public class LambdaGivenStep : LambdaStep
 {
     public LambdaGivenStep()
         : base("Given")

--- a/src/DrillSergeant/GWT/LambdaThenStep.cs
+++ b/src/DrillSergeant/GWT/LambdaThenStep.cs
@@ -1,6 +1,6 @@
 ﻿namespace DrillSergeant.GWT;
 
-public class LambdaThenStep<TInput> : LambdaStep<TInput>
+public class LambdaThenStep : LambdaStep
 {
     public LambdaThenStep()
         : base("Then")

--- a/src/DrillSergeant/GWT/LambdaWhenStep.cs
+++ b/src/DrillSergeant/GWT/LambdaWhenStep.cs
@@ -1,6 +1,6 @@
 ﻿namespace DrillSergeant.GWT;
 
-public class LambdaWhenStep<TInput> : LambdaStep<TInput>
+public class LambdaWhenStep : LambdaStep
 {
     public LambdaWhenStep()
         : base("When")

--- a/src/DrillSergeant/GWT/ThenStep.cs
+++ b/src/DrillSergeant/GWT/ThenStep.cs
@@ -1,6 +1,6 @@
 ﻿namespace DrillSergeant.GWT;
 
-public class ThenStep<TInput> : VerbStep<TInput>
+public class ThenStep : VerbStep
 {
     public ThenStep()
         : base("Then")

--- a/src/DrillSergeant/GWT/WhenStep.cs
+++ b/src/DrillSergeant/GWT/WhenStep.cs
@@ -1,6 +1,6 @@
 ﻿namespace DrillSergeant.GWT;
 
-public class WhenStep<TInput> : VerbStep<TInput>
+public class WhenStep : VerbStep
 {
     public WhenStep()
         : base("When")

--- a/src/DrillSergeant/IBehavior.cs
+++ b/src/DrillSergeant/IBehavior.cs
@@ -5,6 +5,6 @@ namespace DrillSergeant;
 public interface IBehavior : IEnumerable<IStep>
 {
     IDictionary<string,object?> Context { get; }
-    object Input { get; }
+    IDictionary<string,object?> Input { get; }
     bool LogContext { get; }
 }

--- a/src/DrillSergeant/IStep.cs
+++ b/src/DrillSergeant/IStep.cs
@@ -10,5 +10,5 @@ public interface IStep : IDisposable
     
     string Name { get; }
 
-    Task Execute(IDictionary<string,object?> context, object input);
+    Task Execute(IDictionary<string, object?> context, IDictionary<string, object?> input);
 }

--- a/src/DrillSergeant/LambdaStep.cs
+++ b/src/DrillSergeant/LambdaStep.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace DrillSergeant;
 
-public class LambdaStep<TInput> : BaseStep
+public class LambdaStep : BaseStep
 {
     private string? name;
     private Delegate handler = () => { };
@@ -13,9 +13,9 @@ public class LambdaStep<TInput> : BaseStep
         this.Verb = verb;
     }
 
-    public override string Name => this.name ?? this.handler?.Method?.GetType().FullName ?? nameof(LambdaStep<TInput>);
+    public override string Name => this.name ?? this.handler?.Method?.GetType().FullName ?? nameof(LambdaStep);
 
-    public LambdaStep<TInput> Named(string name)
+    public LambdaStep Named(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
@@ -26,7 +26,7 @@ public class LambdaStep<TInput> : BaseStep
         return this;
     }
 
-    private LambdaStep<TInput> SetHandler(Delegate? handler)
+    private LambdaStep SetHandler(Delegate? handler)
     {
         if (handler != null)
         {
@@ -36,15 +36,15 @@ public class LambdaStep<TInput> : BaseStep
         return this;
     }
 
-    public LambdaStep<TInput> Handle(Delegate handler) => this.SetHandler(handler);
+    public LambdaStep Handle(Delegate handler) => this.SetHandler(handler);
 
-    public LambdaStep<TInput> Handle(Action? handler) => this.SetHandler(handler);
-    public LambdaStep<TInput> Handle(Action<dynamic>? handler) => this.SetHandler(handler);
-    public LambdaStep<TInput> Handle(Action<dynamic, TInput>? handler) => this.SetHandler(handler);
+    public LambdaStep Handle(Action? handler) => this.SetHandler(handler);
+    public LambdaStep Handle(Action<dynamic>? handler) => this.SetHandler(handler);
+    public LambdaStep Handle(Action<dynamic, dynamic>? handler) => this.SetHandler(handler);
 
-    public LambdaStep<TInput> Handle(Func<Task>? handler) => this.SetHandler(handler);
-    public LambdaStep<TInput> Handle(Func<dynamic, Task>? handler) => this.SetHandler(handler);
-    public LambdaStep<TInput> Handle(Func<dynamic, TInput, Task>? handler) => this.SetHandler(handler);
+    public LambdaStep Handle(Func<Task>? handler) => this.SetHandler(handler);
+    public LambdaStep Handle(Func<dynamic, Task>? handler) => this.SetHandler(handler);
+    public LambdaStep Handle(Func<dynamic, dynamic, Task>? handler) => this.SetHandler(handler);
 
     protected override Delegate PickHandler() => this.handler;
 }

--- a/src/DrillSergeant/VerbStep.cs
+++ b/src/DrillSergeant/VerbStep.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 namespace DrillSergeant;
 
-public class VerbStep<TInput> : BaseStep
+public class VerbStep : BaseStep
 {
     public record VerbMethod(MethodInfo Method, object Target, bool IsAsync);
 

--- a/test/DrillSergeant.Tests/BaseStepTests.cs
+++ b/test/DrillSergeant.Tests/BaseStepTests.cs
@@ -1,9 +1,6 @@
-﻿using FakeItEasy;
-using Shouldly;
+﻿using Shouldly;
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
@@ -42,29 +39,12 @@ public class BaseStepTests
 
         private readonly MethodInfo stubExecuteMethodWithParameters = GetMethod(typeof(ResolveParametersMethod), nameof(StubExecuteMethodWithParameters));
 
-        [Fact]
-        public void InputParameterResolvesToPassedInput()
-        {
-            // Arrange.
-            var step = A.Fake<BaseStep>(options => options.CallsBaseMethods());
-            dynamic context = new ExpandoObject();
-            var input = new Input();
-            var parameters = stubExecuteMethodWithParameters.GetParameters();
-
-            // Act.
-            var resolvedParameters = (object?[])step.ResolveParameters(context, input, parameters);
-            var resolvedInput = resolvedParameters.First(x => x!.GetType() == typeof(Input));
-
-            // Assert.
-            resolvedInput.ShouldBeSameAs(input);
-        }
-
         private void StubExecuteMethodWithParameters(Context context, Input input)
         {
         }
     }
 
-    public class CastContextMethod : BaseStepTests
+    public class DynamicCastMethod : BaseStepTests
     {
         [Fact]
         public void CallingWithObjectTypeReturnsSource()
@@ -73,7 +53,7 @@ public class BaseStepTests
             var source = new Dictionary<string, object?>();
 
             // Act.
-            var result = BaseStep.CastContext(source, typeof(object));
+            var result = BaseStep.DynamicCast(source, typeof(object));
 
             // Assert.
             source.ShouldBeSameAs(result);
@@ -96,7 +76,7 @@ public class BaseStepTests
             };
 
             // Act.
-            var result = BaseStep.CastContext(source, typeof(StubWithProperties));
+            var result = BaseStep.DynamicCast(source, typeof(StubWithProperties));
 
             // Assert.
             result.ShouldBe(expected);
@@ -112,7 +92,7 @@ public class BaseStepTests
             var source = new Dictionary<string, object?>();
 
             // Act and Assert.
-            Assert.Throws<InvalidOperationException>(() => BaseStep.CastContext(source, type));
+            Assert.Throws<InvalidOperationException>(() => BaseStep.DynamicCast(source, type));
         }
 
         public record StubWithProperties

--- a/test/DrillSergeant.Tests/Features/CalculatorFeature.cs
+++ b/test/DrillSergeant.Tests/Features/CalculatorFeature.cs
@@ -24,11 +24,11 @@ public class CalculatorBehaviors
     [Behavior]
     [InlineAutoData]
     [InlineAutoData]
-    public IBehavior AdditionBehaviorWithAutoData(int a, int b)
+    public Behavior AdditionBehaviorWithAutoData(int a, int b)
     {
         var input = new Input(a, b, a + b);
 
-        return new Behavior<Input>(input)
+        return new Behavior(input)
             .EnableContextLogging()
             .Given("Set first number", (c, i) => c.A = i.A) // Inline step declaration.
             .Given(SetSecondNumber)
@@ -37,9 +37,9 @@ public class CalculatorBehaviors
     }
 
     [Behavior, MemberData(nameof(AdditionInputs))]
-    public Task<Behavior<Input>> AsyncAdditionBehavior(int a, int b, int expected)
+    public Task<Behavior> AsyncAdditionBehavior(int a, int b, int expected)
     {
-        var behavior = new Behavior<Input>(new Input(a, b, expected))
+        var behavior = new Behavior(new Input(a, b, expected))
             .Given("Set first number", (c, i) => c.A = i.A)
             .GivenAsync(SetSecondNumberAsync)
             .When(AddNumbersAsync(calculator))
@@ -49,11 +49,11 @@ public class CalculatorBehaviors
     }
 
     [Behavior, MemberData(nameof(AdditionInputs))]
-    public IBehavior AdditionBehavior(int a, int b, int expected)
+    public Behavior AdditionBehavior(int a, int b, int expected)
     {
         var input = new Input(a, b, expected);
 
-        return new Behavior<Input>(input)
+        return new Behavior(input)
             .EnableContextLogging()
             .Given("Set first number", (c, i) => c.A = i.A) // Inline step declaration.
             .Given(SetSecondNumber)
@@ -64,23 +64,23 @@ public class CalculatorBehaviors
     // Step implemented as a normal method.
     private void SetSecondNumber(dynamic context, Input input) => context.B = input.B;
 
-    private Task SetSecondNumberAsync(dynamic context, Input input)
+    private Task SetSecondNumberAsync(dynamic context, dynamic input)
     {
         context.B = input.B;
         return Task.CompletedTask;
     }
 
     // Step implemented as a lambda step for greater flexibility.
-    public LambdaStep<Input> AddNumbers(Calculator calculator) =>
-        new LambdaWhenStep<Input>()
+    public LambdaStep AddNumbers(Calculator calculator) =>
+        new LambdaWhenStep()
             .Named("Add numbers")
             .Handle((c) =>
             {
                 c.Result = calculator.Add(c.A, c.B);
             });
 
-    public LambdaStep<Input> AddNumbersAsync(Calculator calculator) =>
-        new LambdaWhenStep<Input>()
+    public LambdaStep AddNumbersAsync(Calculator calculator) =>
+        new LambdaWhenStep()
             .Named("Add numbers")
             .Handle((c, _) =>
             {
@@ -89,7 +89,7 @@ public class CalculatorBehaviors
             });
 
     // Step implemented as type for full customization and reusability.
-    public class CheckResultStep : ThenStep<Input>
+    public class CheckResultStep : ThenStep
     {
         public void Then(dynamic context, Input input)
         {
@@ -98,7 +98,7 @@ public class CalculatorBehaviors
     }
 
     // Class-level step.
-    public class CheckResultStepAsync : ThenStep<Input>
+    public class CheckResultStepAsync : ThenStep
     {
         public Task ThenAsync(dynamic context, Input input)
         {

--- a/test/DrillSergeant.Tests/LambdaStepTests.cs
+++ b/test/DrillSergeant.Tests/LambdaStepTests.cs
@@ -1,5 +1,4 @@
-﻿using FakeItEasy;
-using Shouldly;
+﻿using Shouldly;
 using System.Dynamic;
 using System.Threading.Tasks;
 using Xunit;
@@ -10,9 +9,6 @@ public class LambdaStepTests
 {
     public class NamedMethod : LambdaStepTests
     {
-        public record Context();
-        public record Input();
-
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -21,7 +17,7 @@ public class LambdaStepTests
         public void SettingBlankNameDoesNotChangeExistingValue(string blankValue)
         {
             // Arrange.
-            var step = new LambdaStep<Input>("Test").Named("expected");
+            var step = new LambdaStep("Test").Named("expected");
 
             // Act.
             step.Named(blankValue);
@@ -44,13 +40,13 @@ public class LambdaStepTests
         public async Task NonAsyncHandlerWithReturnReturnsValue()
         {
             // Arrange.
-            var step = new LambdaStep<Input>("Test").Handle((c, i) =>
+            var step = new LambdaStep("Test").Handle((c, i) =>
             {
                 c.Value = 1;
             });
 
             dynamic context = new ExpandoObject();
-            var input = new Input();
+            dynamic input = new ExpandoObject();
 
             // Act.
             await step.Execute(context, input);
@@ -63,14 +59,14 @@ public class LambdaStepTests
         public async Task AsyncHandlerWithReturnReturnsValue()
         {
             // Arrange.
-            var step = new LambdaStep<Input>("Test").Handle((c, i) =>
+            var step = new LambdaStep("Test").Handle((c, i) =>
             {
                 c.Value = 1;
                 return Task.CompletedTask;
             });
 
             dynamic context = new ExpandoObject();
-            var input = new Input();
+            dynamic input = new ExpandoObject();
 
             // Act.
             await step.Execute(context, input);

--- a/test/DrillSergeant.Tests/VerbStepTests.cs
+++ b/test/DrillSergeant.Tests/VerbStepTests.cs
@@ -43,7 +43,7 @@ public class VerbStepTests
             Assert.Equal(typeof(StubStep).Name, step.Name);
         }
 
-        public class StubStep : VerbStep<object>
+        public class StubStep : VerbStep
         {
             public StubStep(string verb) : base(verb)
             {
@@ -71,7 +71,7 @@ public class VerbStepTests
             // Arrange.
             var step = new StubStep_NonAsync_ReturnsValue();
             dynamic context = new ExpandoObject();
-            var input = new Input();
+            dynamic input = new ExpandoObject();
 
             // Act.
             await step.Execute(context, input);
@@ -86,7 +86,7 @@ public class VerbStepTests
             // Arrange.
             var step = new StubStep_Async_ReturnsValue();
             dynamic context = new ExpandoObject();
-            var input = new Input();
+            dynamic input = new ExpandoObject();
 
             // Act.
             await step.Execute(context, input);
@@ -95,7 +95,7 @@ public class VerbStepTests
             Assert.Equal(1, context.Value);
         }
 
-        public class StubStep_NonAsync_ReturnsValue : VerbStep<Input>
+        public class StubStep_NonAsync_ReturnsValue : VerbStep
         {
             public StubStep_NonAsync_ReturnsValue() : base("Test")
             {
@@ -104,7 +104,7 @@ public class VerbStepTests
             public void Test(Context context, Input input) => context.Value = 1;
         }
 
-        public class StubStep_Async_ReturnsValue : VerbStep<Input>
+        public class StubStep_Async_ReturnsValue : VerbStep
         {
             public StubStep_Async_ReturnsValue() : base("Test")
             {
@@ -122,7 +122,7 @@ public class VerbStepTests
             void DoSomething();
         }
 
-        public class StubWithNoParameters : VerbStep<Input>
+        public class StubWithNoParameters : VerbStep
         {
             public StubWithNoParameters()
                 : base("Test")
@@ -137,7 +137,7 @@ public class VerbStepTests
             }
         }
 
-        public class StubWithInjectableParameter : VerbStep<Input>
+        public class StubWithInjectableParameter : VerbStep
         {
             public StubWithInjectableParameter()
                 : base("Test")
@@ -150,7 +150,7 @@ public class VerbStepTests
             }
         }
 
-        public class StubThatReturnsValue_Sync : VerbStep<Input>
+        public class StubThatReturnsValue_Sync : VerbStep
         {
             public StubThatReturnsValue_Sync()
                 : base("Test")
@@ -160,7 +160,7 @@ public class VerbStepTests
             public string Test() => "expected";
         }
 
-        public class StubThatReturnsValue_Async : VerbStep<Input>
+        public class StubThatReturnsValue_Async : VerbStep
         {
             public StubThatReturnsValue_Async()
                 : base("Test")
@@ -238,7 +238,7 @@ public class VerbStepTests
             Assert.Throws<AmbiguousVerbException>(() => stub.PickHandlerWrapper());
         }
 
-        public class StubWithExposedPickHandler : VerbStep<object>
+        public class StubWithExposedPickHandler : VerbStep
         {
             public StubWithExposedPickHandler()
                 : base("Test")


### PR DESCRIPTION
Inputs to behaviors now use the same `dynamic` strategy as context.