### PR TITLE
Add support for behaviors without input

### DIFF
--- a/src/DrillSergeant/Behavior.cs
+++ b/src/DrillSergeant/Behavior.cs
@@ -9,6 +9,11 @@ public class Behavior : IBehavior
 {
     protected readonly List<IStep> steps = new();
 
+    public Behavior()
+        : this(new { })
+    {
+    }
+
     public Behavior(object input)
     {
         var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty;

--- a/src/DrillSergeant/BehaviorAttribute.cs
+++ b/src/DrillSergeant/BehaviorAttribute.cs
@@ -7,6 +7,6 @@ namespace DrillSergeant;
 
 [ExcludeFromCodeCoverage, AttributeUsage(AttributeTargets.Method)]
 [XunitTestCaseDiscoverer("DrillSergeant.Core.BehaviorDiscoverer", "DrillSergeant")]
-public sealed class BehaviorAttribute : TheoryAttribute
+public sealed class BehaviorAttribute : FactAttribute
 {
 }

--- a/src/DrillSergeant/Core/BehaviorDiscoverer.cs
+++ b/src/DrillSergeant/Core/BehaviorDiscoverer.cs
@@ -12,13 +12,13 @@ public class BehaviorDiscoverer : TheoryDiscoverer
         : base(diagnosticMessageSink)
     {
         // Uncomment this line to debug behavior discovery.
-        // System.Diagnostics.Debugger.Launch();
+        System.Diagnostics.Debugger.Launch();
     }
 
     protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
     {
-        return new[] 
-        { 
+        return new[]
+        {
             new BehaviorTestCase(
                 DiagnosticMessageSink,
                 discoveryOptions.MethodDisplayOrDefault(),
@@ -42,7 +42,10 @@ public class BehaviorDiscoverer : TheoryDiscoverer
 
     public override IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
     {
-        if (testMethod.Method.GetParameters().Any())
+        var dataAttributes = testMethod.Method.GetCustomAttributes(typeof(DataAttribute));
+        var hasParameters = testMethod.Method.GetParameters().Any();
+
+        if (dataAttributes.Any() || hasParameters)
         {
             return base.Discover(discoveryOptions, testMethod, theoryAttribute);
         }

--- a/src/DrillSergeant/Core/BehaviorDiscoverer.cs
+++ b/src/DrillSergeant/Core/BehaviorDiscoverer.cs
@@ -12,7 +12,7 @@ public class BehaviorDiscoverer : TheoryDiscoverer
         : base(diagnosticMessageSink)
     {
         // Uncomment this line to debug behavior discovery.
-        System.Diagnostics.Debugger.Launch();
+        // System.Diagnostics.Debugger.Launch();
     }
 
     protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)

--- a/src/DrillSergeant/Core/BehaviorDiscoverer.cs
+++ b/src/DrillSergeant/Core/BehaviorDiscoverer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -35,6 +37,24 @@ public class BehaviorDiscoverer : TheoryDiscoverer
                 discoveryOptions.MethodDisplayOrDefault(),
                 discoveryOptions.MethodDisplayOptionsOrDefault(),
                 testMethod)
+        };
+    }
+
+    public override IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+    {
+        if (testMethod.Method.GetParameters().Any())
+        {
+            return base.Discover(discoveryOptions, testMethod, theoryAttribute);
+        }
+
+        return new[]
+        {
+            new BehaviorTestCase(
+                DiagnosticMessageSink,
+                discoveryOptions.MethodDisplayOrDefault(),
+                discoveryOptions.MethodDisplayOptionsOrDefault(),
+                testMethod,
+                Array.Empty<object>())
         };
     }
 }

--- a/test/DrillSergeant.Tests/Features/BaseStepFeature.cs
+++ b/test/DrillSergeant.Tests/Features/BaseStepFeature.cs
@@ -5,8 +5,8 @@ namespace DrillSergeant.Tests.Features;
 
 public class BaseStepFeature
 {
-    [Behavior, InlineData(0)]
-    public Behavior ModifyingInputFails(int _)
+    [Behavior]
+    public Behavior ModifyingInputFails()
     {
         var input = new
         {

--- a/test/DrillSergeant.Tests/Features/BaseStepFeature.cs
+++ b/test/DrillSergeant.Tests/Features/BaseStepFeature.cs
@@ -17,4 +17,11 @@ public class BaseStepFeature
             .When("Update input", (c, i) => i.Value = "error")
             .Then("Input should be unchanged", (c, i) => Assert.Equal("expected", i.Value));
     }
+
+    [Behavior]
+    public Behavior CreatingBehaviorWithoutInputCreatesEmptyBag()
+    {
+        return new Behavior()
+            .Then("The input should be non-null", (c, i) => Assert.NotNull(i));
+    }
 }

--- a/test/DrillSergeant.Tests/Features/CalculatorFeature.cs
+++ b/test/DrillSergeant.Tests/Features/CalculatorFeature.cs
@@ -17,7 +17,8 @@ public class CalculatorFeature
         get => new[]
         {
             new object[] { 1, 2, 3 },
-            new object[] { 2, 3, 5 }
+            new object[] { 2, 3, 5 },
+            new object[] { 3, 4, 7 }
         };
     }
 


### PR DESCRIPTION
Added support for creating behavior methods that do not rely on data (e.g. `InlineData`, `MemberData`, etc...).

This was done by changing `BehaviorAttribute` to derive from `FactAttribute` instead of `TheoryAttribute` and adding a hook into the discoverer's `Discovery()` method to manually create single test cases in the event that no `DataAttribute` is present on the method.