### PR TITLE
Added support for marking a step as skipped.

### DIFF
--- a/src/DrillSergeant/BaseStep.cs
+++ b/src/DrillSergeant/BaseStep.cs
@@ -25,6 +25,9 @@ public abstract class BaseStep : IStep
     /// <inheritdoc />
     public virtual string Name => "<untitled step>";
 
+    /// <inheritdoc />
+    public virtual bool ShouldSkip { get; protected set; }
+
     [ExcludeFromCodeCoverage]
     ~BaseStep()
     {

--- a/src/DrillSergeant/BehaviorExecutor.cs
+++ b/src/DrillSergeant/BehaviorExecutor.cs
@@ -32,7 +32,7 @@ namespace DrillSergeant
                    throw new InvalidOperationException("Test method did not return a behavior.");
         }
 
-        public async Task Execute(IBehavior behavior)
+        public async Task Execute(IBehavior? behavior)
         {
             bool previousStepFailed = false;
 
@@ -48,6 +48,12 @@ namespace DrillSergeant
                 if (previousStepFailed)
                 {
                     _reporter.WriteStepResult(step.Verb, step.Name, previousStepFailed, elapsed: 0, success: false, context: null);
+                    continue;
+                }
+
+                if (step.ShouldSkip)
+                {
+                    _reporter.WriteStepResult(step.Verb, step.Name, skipped: true, elapsed: 0, success: true, context: null);
                     continue;
                 }
 

--- a/src/DrillSergeant/IStep.cs
+++ b/src/DrillSergeant/IStep.cs
@@ -20,6 +20,11 @@ public interface IStep : IDisposable
     string Name { get; }
 
     /// <summary>
+    /// Gets a value indicating whether the step should be skipped.
+    /// </summary>
+    bool ShouldSkip { get; }
+
+    /// <summary>
     /// Executes the step.
     /// </summary>
     /// <param name="context">The context to bind to the step handler.</param>

--- a/src/DrillSergeant/LambdaStep.cs
+++ b/src/DrillSergeant/LambdaStep.cs
@@ -12,6 +12,7 @@ public class LambdaStep : BaseStep
 {
     private string? _name;
     private Delegate? _handler;
+    private Func<bool> _shouldSkip = () => false;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LambdaStep"/> class.
@@ -33,6 +34,9 @@ public class LambdaStep : BaseStep
 
     /// <inheritdoc />
     public override string Name => _name ?? _handler?.Method.Name ?? GetType().Name;
+
+    /// <inheritdoc />
+    public override bool ShouldSkip => _shouldSkip();
 
     /// <summary>
     /// Sets the name of the step.
@@ -59,6 +63,16 @@ public class LambdaStep : BaseStep
         }
 
         Verb = verb.Trim();
+        return this;
+    }
+
+    public LambdaStep Skip(Func<bool>? shouldSkip = null)
+    {
+        if (shouldSkip != null)
+        {
+            _shouldSkip = shouldSkip;
+        }
+
         return this;
     }
 

--- a/test/DrillSergeant.Tests/LambdaStepTests.cs
+++ b/test/DrillSergeant.Tests/LambdaStepTests.cs
@@ -47,6 +47,50 @@ public class LambdaStepTests
         }
     }
 
+    public class SkipMethod : LambdaStepTests
+    {
+        [Fact]
+        public void SkipDisabledByDefault()
+        {
+            // Arrange.
+            var step = new LambdaStep();
+
+            // Act.
+            var result = step.ShouldSkip;
+
+            // Assert.
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void NullPredicateDisablesSkip()
+        {
+            // Arrange.
+            var step = new LambdaStep();
+
+            // Act.
+            step.Skip();
+            var result = step.ShouldSkip;
+
+            // Assert.
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void NotNullPredicateEnablesSkip()
+        {
+            // Arrange.
+            var step = new LambdaStep();
+
+            // Act.
+            step.Skip(() => true);
+            var result = step.ShouldSkip;
+
+            // Assert.
+            result.ShouldBeTrue();
+        }
+    }
+
     public class ExecuteMethod : LambdaStepTests
     {
         public record Context


### PR DESCRIPTION
The `IStep` interface now contains a boolean property for `ShouldSkip`.  The `BehaviorExecutor` class now takes this into consideration before executing a step.

`VerbStep` uses `BaseStep` property.
`LambdaStep` provides an override and configurable handler set by calling `Skip()`.