### PR TITLE
Added support for MSTest

### DIFF
--- a/DrillSergeant.sln
+++ b/DrillSergeant.sln
@@ -28,6 +28,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrillSergeant.Tests.NUnit3"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrillSergeant.Tests.Xunit2", "test\DrillSergeant.Tests.Xunit2\DrillSergeant.Tests.Xunit2.csproj", "{E0D70886-43AA-48F0-85C7-2AC1722CD3E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DrillSergeant.Tests.MSTest", "test\DrillSergeant.Tests.MSTest\DrillSergeant.Tests.MSTest.csproj", "{F6874C05-BBF0-4327-9AAE-A3637887F0C0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DrillSergeant.MSTest", "src\DrillSergeant.MSTest\DrillSergeant.MSTest.csproj", "{4E047335-5497-4401-8C6D-DAC3F63AE668}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +66,14 @@ Global
 		{E0D70886-43AA-48F0-85C7-2AC1722CD3E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E0D70886-43AA-48F0-85C7-2AC1722CD3E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E0D70886-43AA-48F0-85C7-2AC1722CD3E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6874C05-BBF0-4327-9AAE-A3637887F0C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6874C05-BBF0-4327-9AAE-A3637887F0C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6874C05-BBF0-4327-9AAE-A3637887F0C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6874C05-BBF0-4327-9AAE-A3637887F0C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E047335-5497-4401-8C6D-DAC3F63AE668}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E047335-5497-4401-8C6D-DAC3F63AE668}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E047335-5497-4401-8C6D-DAC3F63AE668}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E047335-5497-4401-8C6D-DAC3F63AE668}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -75,6 +87,8 @@ Global
 		{99E31B7B-AE5C-46E9-848D-3DE6FFA23864} = {BFEDAF09-08D0-463B-9922-8D90085D92FF}
 		{ACB0FA68-FC24-4F90-979B-7651FC667E5E} = {F6F6AA0B-F5E0-496C-A763-48ADC3542836}
 		{E0D70886-43AA-48F0-85C7-2AC1722CD3E2} = {F6F6AA0B-F5E0-496C-A763-48ADC3542836}
+		{F6874C05-BBF0-4327-9AAE-A3637887F0C0} = {F6F6AA0B-F5E0-496C-A763-48ADC3542836}
+		{4E047335-5497-4401-8C6D-DAC3F63AE668} = {BFEDAF09-08D0-463B-9922-8D90085D92FF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {35E642DB-4DFA-4054-B035-03F437C3F8BD}

--- a/DrillSergeant.sln
+++ b/DrillSergeant.sln
@@ -97,5 +97,6 @@ Global
 		test\DrillSergeant.Tests.Shared\DrillSergeant.Tests.Shared.projitems*{acb0fa68-fc24-4f90-979b-7651fc667e5e}*SharedItemsImports = 5
 		test\DrillSergeant.Tests.Shared\DrillSergeant.Tests.Shared.projitems*{e0d70886-43aa-48f0-85c7-2ac1722cd3e2}*SharedItemsImports = 5
 		test\DrillSergeant.Tests.Shared\DrillSergeant.Tests.Shared.projitems*{ea885484-0eab-47c2-ac8c-99ca3a0d0fb4}*SharedItemsImports = 13
+		test\DrillSergeant.Tests.Shared\DrillSergeant.Tests.Shared.projitems*{f6874c05-bbf0-4327-9aae-a3637887f0c0}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/DrillSergeant.sln
+++ b/DrillSergeant.sln
@@ -28,9 +28,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrillSergeant.Tests.NUnit3"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrillSergeant.Tests.Xunit2", "test\DrillSergeant.Tests.Xunit2\DrillSergeant.Tests.Xunit2.csproj", "{E0D70886-43AA-48F0-85C7-2AC1722CD3E2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DrillSergeant.Tests.MSTest", "test\DrillSergeant.Tests.MSTest\DrillSergeant.Tests.MSTest.csproj", "{F6874C05-BBF0-4327-9AAE-A3637887F0C0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrillSergeant.Tests.MSTest", "test\DrillSergeant.Tests.MSTest\DrillSergeant.Tests.MSTest.csproj", "{F6874C05-BBF0-4327-9AAE-A3637887F0C0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DrillSergeant.MSTest", "src\DrillSergeant.MSTest\DrillSergeant.MSTest.csproj", "{4E047335-5497-4401-8C6D-DAC3F63AE668}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrillSergeant.MSTest", "src\DrillSergeant.MSTest\DrillSergeant.MSTest.csproj", "{4E047335-5497-4401-8C6D-DAC3F63AE668}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/DrillSergeant.MSTest/AssemblyInfo.cs
+++ b/src/DrillSergeant.MSTest/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DrillSergeant.Tests.MSTest")]

--- a/src/DrillSergeant.MSTest/BehaviorAttribute.cs
+++ b/src/DrillSergeant.MSTest/BehaviorAttribute.cs
@@ -51,10 +51,10 @@ public sealed class BehaviorAttribute : TestMethodAttribute
 
             return ExecuteInternal(
                 new BehaviorExecutor(reporter),
-                classInstance, 
-                method, 
-                arguments ?? Array.Empty<object?>(), 
-                timeout, 
+                classInstance,
+                method,
+                arguments ?? Array.Empty<object?>(),
+                timeout,
                 cancelToken);
         });
 
@@ -74,11 +74,11 @@ public sealed class BehaviorAttribute : TestMethodAttribute
     }
 
     internal static TestResult ExecuteInternal(
-        BehaviorExecutor executor, 
-        object classInstance, 
-        MethodInfo method, 
-        object?[] arguments, 
-        int timeout, 
+        BehaviorExecutor executor,
+        object classInstance,
+        MethodInfo method,
+        object?[] arguments,
+        int timeout,
         CancellationToken cancelToken)
     {
         var waitTimeout = timeout == 0 ? int.MaxValue : timeout * 1000;

--- a/src/DrillSergeant.MSTest/BehaviorAttribute.cs
+++ b/src/DrillSergeant.MSTest/BehaviorAttribute.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Diagnostics.CodeAnalysis;
+using DrillSergeant.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 // ReSharper disable once CheckNamespace
 namespace DrillSergeant;
@@ -7,7 +9,24 @@ namespace DrillSergeant;
 /// Defines an attribute used to notify the test runner that the method is a behavior test.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
-public sealed class BehaviorAttribute : TestMethodAttribute 
+public sealed class BehaviorAttribute : TestMethodAttribute
 {
+    // ReSharper disable once UnusedMember.Global
+    [Obsolete("Feature properties in the Behavior attribute do not work for MSTest.  Use [TestCategory] instead.")]
+    [ExcludeFromCodeCoverage]
     public string? Feature { get; set; }
+
+    public override TestResult[] Execute(ITestMethod testMethod)
+    {
+        var context = GetContext(testMethod);
+
+        return base.Execute(testMethod);
+    }
+
+    private static TestContext? GetContext(ITestMethod testMethod)
+    {
+        return testMethod
+            .GetPrivateProperty("TestMethodOptions")
+            ?.GetPrivateProperty("TestContext") as TestContext;
+    }
 }

--- a/src/DrillSergeant.MSTest/BehaviorAttribute.cs
+++ b/src/DrillSergeant.MSTest/BehaviorAttribute.cs
@@ -142,15 +142,19 @@ public sealed class BehaviorAttribute : TestMethodAttribute
         return (stopwatch.Elapsed, result);
     }
 
+    [ExcludeFromCodeCoverage]
     private static TestResult TestResultPassed() =>
         NewResult(UnitTestOutcome.Passed);
 
+    [ExcludeFromCodeCoverage]
     private static TestResult TestResultFailed(Exception? exception = null) =>
         NewResult(UnitTestOutcome.Failed, exception);
 
+    [ExcludeFromCodeCoverage]
     private static TestResult TestResultTimeout(Exception? exception = null) =>
         NewResult(UnitTestOutcome.Timeout, exception);
 
+    [ExcludeFromCodeCoverage]
     private static TestResult TestResultAborted(Exception? exception = null) =>
         NewResult(UnitTestOutcome.Aborted, exception);
 

--- a/src/DrillSergeant.MSTest/BehaviorAttribute.cs
+++ b/src/DrillSergeant.MSTest/BehaviorAttribute.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+// ReSharper disable once CheckNamespace
+namespace DrillSergeant;
+
+/// <summary>
+/// Defines an attribute used to notify the test runner that the method is a behavior test.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class BehaviorAttribute : TestMethodAttribute 
+{
+    public string? Feature { get; set; }
+}

--- a/src/DrillSergeant.MSTest/BehaviorAttribute.cs
+++ b/src/DrillSergeant.MSTest/BehaviorAttribute.cs
@@ -1,5 +1,8 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using DrillSergeant.MSTest;
+using DrillSergeant.MSTest.Reporting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 // ReSharper disable once CheckNamespace
@@ -18,15 +21,141 @@ public sealed class BehaviorAttribute : TestMethodAttribute
 
     public override TestResult[] Execute(ITestMethod testMethod)
     {
-        var context = GetContext(testMethod);
+        var options = testMethod
+            .GetPrivateProperty("TestMethodOptions")
+            ?.CoerceCast<TestMethodOptions>();
 
-        return base.Execute(testMethod);
+        dynamic context = options?.TestContext!;
+        var reporter = GetReporter(options?.TestContext);
+        using var listener = new LogListener();
+
+        var (elapsed, result) = TimedCall(() =>
+        {
+            object? classInstance;
+            var method = testMethod.MethodInfo;
+            var arguments = testMethod.Arguments;
+            var timeout = options?.Timeout ?? 0;
+            var cancelToken = options?.TestContext.CancellationTokenSource.Token ?? CancellationToken.None;
+
+            try
+            {
+                classInstance = CreateTestClassInstance(testMethod.MethodInfo.DeclaringType);
+            }
+            catch (TestFailedException ex)
+            {
+                return new TestResult
+                {
+                    Outcome = UnitTestOutcome.Failed,
+                    TestFailureException = ex
+                };
+            }
+
+            return ExecuteInternal(classInstance, method, arguments, timeout, cancelToken);
+        });
+
+        result.Duration = elapsed;
+        result.DebugTrace = listener.GetAndClearTrace();
+        result.LogOutput = listener.GetAndClearStdOut();
+        result.LogError = listener.GetAndClearStdErr();
+        result.TestContextMessages = context.GetDiagnosticMessages();
+        result.ResultFiles = context.GetResultFiles();
+
+        context.ClearDiagnosticMessages();
+
+        return new []
+        {
+            result
+        };
     }
 
-    private static TestContext? GetContext(ITestMethod testMethod)
+    private TestResult ExecuteInternal(object classInstance, MethodInfo method, object?[]? arguments, int timeout, CancellationToken cancelToken)
     {
-        return testMethod
-            .GetPrivateProperty("TestMethodOptions")
-            ?.GetPrivateProperty("TestContext") as TestContext;
+        var waitTimeout = timeout == 0 ? Int32.MaxValue : timeout;
+        var cancellationTokenSource = new CancellationTokenSource();
+
+        var task = Task.Run(() =>
+        {
+            method.Invoke(classInstance, arguments);
+        }, cancelToken);
+
+        try
+        {
+            cancellationTokenSource.CancelAfter(waitTimeout);
+            task.Wait(cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException ex)
+        {
+            if (cancelToken.IsCancellationRequested)
+            {
+                return new TestResult
+                {
+                    Outcome = UnitTestOutcome.Aborted,
+                    TestFailureException = ex,
+                };
+            }
+
+            return new TestResult
+            {
+                Outcome = UnitTestOutcome.Timeout,
+                TestFailureException = ex,
+            };
+        }
+        catch (Exception ex)
+        {
+            return new TestResult
+            {
+                Outcome = UnitTestOutcome.Failed,
+                TestFailureException = ex,
+            };
+        }
+
+        return new TestResult
+        {
+            Outcome = UnitTestOutcome.Passed
+        };
+    }
+
+    private static (TimeSpan, TestResult) TimedCall(Func<TestResult> action)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var result = action();
+        
+        return (stopwatch.Elapsed, result);
+    }
+
+    private static ITestReporter GetReporter(TestContext? context) =>
+        context != null ? new RawTestReporter(context) : new NullTestReporter();
+
+    internal static object CreateTestClassInstance(Type? type)
+    {
+        if (type == null)
+        {
+            throw new TestFailedException("The declaring type for the test method could not be determined.");
+        }
+
+        var ctor = type.GetConstructor(Array.Empty<Type>());
+
+        if (ctor == null)
+        {
+            throw new TestFailedException("Unable to find a constructor with zero parameters for the test class.");
+        }
+
+        try
+        {
+            return ctor.Invoke(null);
+        }
+        catch (Exception ex)
+        {
+            throw new TestFailedException("Unable to instantiate new test class instance.", ex);
+        }
+    }
+}
+
+[Serializable]
+public class TestFailedException : Exception
+{
+    public TestFailedException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
     }
 }

--- a/src/DrillSergeant.MSTest/BehaviorTraceListener.cs
+++ b/src/DrillSergeant.MSTest/BehaviorTraceListener.cs
@@ -1,7 +1,9 @@
 ﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DrillSergeant.MSTest;
 
+[ExcludeFromCodeCoverage]
 public class BehaviorTraceListener : TraceListener
 {
     private readonly TextWriter _target;

--- a/src/DrillSergeant.MSTest/BehaviorTraceListener.cs
+++ b/src/DrillSergeant.MSTest/BehaviorTraceListener.cs
@@ -1,0 +1,14 @@
+﻿using System.Diagnostics;
+
+namespace DrillSergeant.MSTest;
+
+public class BehaviorTraceListener : TraceListener
+{
+    private readonly TextWriter _target;
+
+    public BehaviorTraceListener(TextWriter target) => _target = target;
+
+    public override void Write(string? message) => _target.Write(message);
+
+    public override void WriteLine(string? message) => _target.WriteLine(message);
+}

--- a/src/DrillSergeant.MSTest/DrillSergeant.MSTest.csproj
+++ b/src/DrillSergeant.MSTest/DrillSergeant.MSTest.csproj
@@ -18,6 +18,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
 	  <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
 	</ItemGroup>
 

--- a/src/DrillSergeant.MSTest/DrillSergeant.MSTest.csproj
+++ b/src/DrillSergeant.MSTest/DrillSergeant.MSTest.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<AssemblyName>DrillSergeant.MSTest</AssemblyName>
+		<Company>BitCobblers</Company>
+		<Authors>BitCobblers</Authors>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<Version>0.1.0-beta</Version>
+		<PackageProjectUrl>https://github.com/bitcobblers/DrillSergeant</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/bitcobblers/DrillSergeant</RepositoryUrl>
+		<PackageTags>xunit;unit testing; behavior testing; acceptance testing</PackageTags>
+		<RepositoryType>git</RepositoryType>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<Title>Drill Sergeant</Title>
+		<Description>Write acceptance tests in pure C#.</Description>
+	</PropertyGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\DrillSergeant\DrillSergeant.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/DrillSergeant.MSTest/LogListener.cs
+++ b/src/DrillSergeant.MSTest/LogListener.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 
@@ -19,7 +20,7 @@ public class LogListener : IDisposable
 
     private bool _disposed;
 
-    public LogListener()
+    public LogListener(bool captureTraceLogs)
     {
         Logger.OnLogMessage += _redirectStdOut.WriteLine;
 
@@ -28,6 +29,11 @@ public class LogListener : IDisposable
 
         Console.SetOut(_redirectStdOut);
         Console.SetError(_redirectStdErr);
+
+        if (captureTraceLogs == false)
+        {
+            return;
+        }
 
         lock (TraceLock)
         {
@@ -42,6 +48,7 @@ public class LogListener : IDisposable
         }
     }
 
+    [ExcludeFromCodeCoverage]
     ~LogListener() => Dispose(disposing: false);
 
     public string GetAndClearStdOut() => _redirectStdOut.ToStringAndClear();

--- a/src/DrillSergeant.MSTest/LogListener.cs
+++ b/src/DrillSergeant.MSTest/LogListener.cs
@@ -66,16 +66,14 @@ public class LogListener : IDisposable
 
             lock (TraceLock)
             {
-                if (_traceCount == 0)
+                if (_traceCount == 1)
                 {
                     Trace.Listeners.Remove(_traceListener);
                     _traceListener?.Dispose();
                     _redirectTraceDebug?.Dispose();
                 }
-                else
-                {
-                    _traceCount--;
-                }
+                
+                _traceCount--;
             }
         }
 

--- a/src/DrillSergeant.MSTest/LogListener.cs
+++ b/src/DrillSergeant.MSTest/LogListener.cs
@@ -10,11 +10,11 @@ public class LogListener : IDisposable
     private static ThreadSafeStringWriter? _redirectTraceDebug;
     private static BehaviorTraceListener? _traceListener;
     private static int _traceCount = 0;
-    private static readonly object TraceLock = new ();
+    private static readonly object TraceLock = new();
 
     private readonly TextWriter _originalStdOut;
     private readonly TextWriter _originalStdErr;
-    
+
     private readonly ThreadSafeStringWriter _redirectStdOut = new(CultureInfo.InvariantCulture, "stdout");
     private readonly ThreadSafeStringWriter _redirectStdErr = new(CultureInfo.InvariantCulture, "stderr");
 
@@ -79,7 +79,7 @@ public class LogListener : IDisposable
                     _traceListener?.Dispose();
                     _redirectTraceDebug?.Dispose();
                 }
-                
+
                 _traceCount--;
             }
         }

--- a/src/DrillSergeant.MSTest/LogListener.cs
+++ b/src/DrillSergeant.MSTest/LogListener.cs
@@ -1,0 +1,84 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
+
+namespace DrillSergeant.MSTest;
+
+public class LogListener : IDisposable
+{
+    private static ThreadSafeStringWriter? _redirectTraceDebug;
+    private static BehaviorTraceListener? _traceListener;
+    private static int _traceCount = 0;
+    private static readonly object TraceLock = new ();
+
+    private readonly TextWriter _originalStdOut;
+    private readonly TextWriter _originalStdErr;
+    
+    private readonly ThreadSafeStringWriter _redirectStdOut = new(CultureInfo.InvariantCulture, "stdout");
+    private readonly ThreadSafeStringWriter _redirectStdErr = new(CultureInfo.InvariantCulture, "stderr");
+
+    private bool _disposed;
+
+    public LogListener()
+    {
+        Logger.OnLogMessage += _redirectStdOut.WriteLine;
+
+        _originalStdOut = Console.Out;
+        _originalStdErr = Console.Error;
+
+        Console.SetOut(_redirectStdOut);
+        Console.SetError(_redirectStdErr);
+
+        lock (TraceLock)
+        {
+            if (_traceCount == 0)
+            {
+                _redirectTraceDebug = new(CultureInfo.InvariantCulture, "trace");
+                _traceListener = new BehaviorTraceListener(_redirectTraceDebug);
+                Trace.Listeners.Add(_traceListener);
+            }
+
+            _traceCount++;
+        }
+    }
+
+    ~LogListener() => Dispose(disposing: false);
+
+    public string GetAndClearStdOut() => _redirectStdOut.ToStringAndClear();
+    public string GetAndClearStdErr() => _redirectStdErr.ToStringAndClear();
+    public string GetAndClearTrace() => _redirectTraceDebug?.ToStringAndClear() ?? string.Empty;
+
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing && !_disposed)
+        {
+            Console.SetOut(_originalStdOut);
+            Console.SetError(_originalStdErr);
+
+            _redirectStdOut.Dispose();
+            _redirectStdErr.Dispose();
+
+            lock (TraceLock)
+            {
+                if (_traceCount == 0)
+                {
+                    Trace.Listeners.Remove(_traceListener);
+                    _traceListener?.Dispose();
+                    _redirectTraceDebug?.Dispose();
+                }
+                else
+                {
+                    _traceCount--;
+                }
+            }
+        }
+
+        _disposed = true;
+    }
+}

--- a/src/DrillSergeant.MSTest/ObjectExtensions.cs
+++ b/src/DrillSergeant.MSTest/ObjectExtensions.cs
@@ -13,4 +13,34 @@ public static class ObjectExtensions
 
         return propertyInfo?.GetValue(instance);
     }
+
+    public static T CoerceCast<T>(this object source) where T : class, new()
+    {
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        var target = new T();
+
+        var sourceProperties = source.GetType().GetProperties(flags).ToDictionary(k => k.Name, v => v);
+        var targetProperties = target.GetType().GetProperties(flags).ToDictionary(k => k.Name, v => v);
+
+        var commonProperties = sourceProperties.Keys.Intersect(targetProperties.Keys);
+
+        foreach (var propertyName in commonProperties)
+        {
+            var sourceProperty = sourceProperties[propertyName];
+            var targetProperty = targetProperties[propertyName];
+            var value = sourceProperty.GetValue(source);
+
+            if (value == null)
+            {
+                continue;
+            }
+
+            if (value.GetType().IsAssignableTo(targetProperty.PropertyType))
+            {
+                targetProperty.SetValue(target, value);
+            }
+        }
+
+        return target;
+    }
 }

--- a/src/DrillSergeant.MSTest/ObjectExtensions.cs
+++ b/src/DrillSergeant.MSTest/ObjectExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+
+namespace DrillSergeant.MSTest;
+
+public static class ObjectExtensions
+{
+    public static object? GetPrivateProperty(this object instance, string property)
+    {
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+
+        var instanceType = instance.GetType();
+        var propertyInfo = instanceType.GetProperty(property, flags);
+
+        return propertyInfo?.GetValue(instance);
+    }
+}

--- a/src/DrillSergeant.MSTest/Reporting/NullTestReporter.cs
+++ b/src/DrillSergeant.MSTest/Reporting/NullTestReporter.cs
@@ -1,0 +1,21 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace DrillSergeant.MSTest.Reporting
+{
+    [ExcludeFromCodeCoverage]
+    public class NullTestReporter : ITestReporter
+    {
+        public void Dispose()
+        {
+        }
+
+        public string Output => string.Empty;
+        public void WriteBlock(string label, object content)
+        {
+        }
+
+        public void WriteStepResult(string verb, string name, bool skipped, decimal elapsed, bool success, object? context)
+        {
+        }
+    }
+}

--- a/src/DrillSergeant.MSTest/Reporting/RawTestReporter.cs
+++ b/src/DrillSergeant.MSTest/Reporting/RawTestReporter.cs
@@ -1,15 +1,10 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DrillSergeant.MSTest.Reporting;
 
 public class RawTestReporter : ITestReporter
 {
-    private readonly TestContext _context;
-
-    public RawTestReporter(TestContext context) => _context = context;
-
     [ExcludeFromCodeCoverage]
     public void Dispose()
     {
@@ -27,8 +22,8 @@ public class RawTestReporter : ITestReporter
         };
 
         var serializedContent = JsonConvert.SerializeObject(content, serializationSettings);
-        _context.WriteLine($"{label}: {serializedContent}");
-        _context.WriteLine(string.Empty);
+        Console.WriteLine($"{label}: {serializedContent}");
+        Console.WriteLine(string.Empty);
     }
 
     public void WriteStepResult(string verb, string name, bool skipped, decimal elapsed, bool success, object? context)
@@ -37,11 +32,11 @@ public class RawTestReporter : ITestReporter
 
         if (skipped)
         {
-            _context.WriteLine($"⏩ {verb} (skipped due to previous failure): {name}");
+            Console.WriteLine($"⏩ {verb} (skipped due to previous failure): {name}");
         }
         else
         {
-            _context.WriteLine($"{icon} {verb}: {name} took {elapsed:N2}s");
+            Console.WriteLine($"{icon} {verb}: {name} took {elapsed:N2}s");
 
             if (context != null)
             {

--- a/src/DrillSergeant.MSTest/Reporting/RawTestReporter.cs
+++ b/src/DrillSergeant.MSTest/Reporting/RawTestReporter.cs
@@ -1,0 +1,52 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace DrillSergeant.MSTest.Reporting;
+
+public class RawTestReporter : ITestReporter
+{
+    private readonly TestContext _context;
+
+    public RawTestReporter(TestContext context) => _context = context;
+
+    [ExcludeFromCodeCoverage]
+    public void Dispose()
+    {
+    }
+
+    [ExcludeFromCodeCoverage]
+    public string Output => string.Empty;
+
+    public void WriteBlock(string label, object content)
+    {
+        var serializationSettings = new JsonSerializerSettings
+        {
+            Formatting = Formatting.Indented,
+            Error = (_, e) => e.ErrorContext.Handled = true
+        };
+
+        var serializedContent = JsonConvert.SerializeObject(content, serializationSettings);
+        _context.WriteLine($"{label}: {serializedContent}");
+        _context.WriteLine(string.Empty);
+    }
+
+    public void WriteStepResult(string verb, string name, bool skipped, decimal elapsed, bool success, object? context)
+    {
+        var icon = success ? "✅" : "❎";
+
+        if (skipped)
+        {
+            _context.WriteLine($"⏩ {verb} (skipped due to previous failure): {name}");
+        }
+        else
+        {
+            _context.WriteLine($"{icon} {verb}: {name} took {elapsed:N2}s");
+
+            if (context != null)
+            {
+                WriteBlock("Context", context);
+            }
+        }
+    }
+}

--- a/src/DrillSergeant.MSTest/TestFailedException.cs
+++ b/src/DrillSergeant.MSTest/TestFailedException.cs
@@ -1,0 +1,10 @@
+﻿namespace DrillSergeant.MSTest;
+
+[Serializable]
+public class TestFailedException : Exception
+{
+    public TestFailedException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/DrillSergeant.MSTest/TestMethodOptions.cs
+++ b/src/DrillSergeant.MSTest/TestMethodOptions.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DrillSergeant.MSTest;
+
+public class TestMethodOptions
+{
+    public int Timeout { get; set; }
+    public TestContext TestContext { get; set; }
+    public bool CaptureDebugTraces { get; set; }
+}

--- a/src/DrillSergeant.MSTest/ThreadSafeStringBuilder.cs
+++ b/src/DrillSergeant.MSTest/ThreadSafeStringBuilder.cs
@@ -1,0 +1,31 @@
+﻿using System.Text;
+
+namespace DrillSergeant.MSTest;
+
+internal class ThreadSafeStringBuilder
+{
+    private readonly StringBuilder _builder = new();
+    private readonly object _sync = new();
+
+    public void Clear() => Wrap(() => _builder.Clear());
+
+    public void AppendLine(string? value) => Wrap(() => _builder.AppendLine(value));
+
+    public override string ToString() => WrapFunc(() => _builder.ToString());
+
+    private void Wrap(Action action)
+    {
+        lock (_sync)
+        {
+            action.Invoke();
+        }
+    }
+
+    private T WrapFunc<T>(Func<T> func)
+    {
+        lock (_sync)
+        {
+            return func();
+        }
+    }
+}

--- a/src/DrillSergeant.MSTest/ThreadSafeStringWriter.cs
+++ b/src/DrillSergeant.MSTest/ThreadSafeStringWriter.cs
@@ -46,6 +46,15 @@ public class ThreadSafeStringWriter : StringWriter
         }
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        lock (GlobalSync)
+        {
+            State.Value?.Remove(_kind);
+            base.Dispose(disposing);
+        }
+    }
+
     private ThreadSafeStringBuilder GetOrAdd()
     {
         lock (GlobalSync)

--- a/src/DrillSergeant.MSTest/ThreadSafeStringWriter.cs
+++ b/src/DrillSergeant.MSTest/ThreadSafeStringWriter.cs
@@ -1,0 +1,79 @@
+﻿namespace DrillSergeant.MSTest;
+
+public class ThreadSafeStringWriter : StringWriter
+{
+    private static readonly AsyncLocal<Dictionary<string, ThreadSafeStringBuilder>> State = new();
+
+    private static readonly object GlobalSync = new();
+    private readonly string _kind;
+
+    public ThreadSafeStringWriter(IFormatProvider formatProvider, string kind)
+        : base(formatProvider)
+    {
+        _kind = kind;
+
+        // Force the writer to be pulled into this level of the async stack.
+        _ = ToStringAndClear();
+    }
+
+    public override void WriteLine(string? value) => GetOrAdd().AppendLine(value);
+
+    public override string ToString()
+    {
+        try
+        {
+            return GetOrNull()?.ToString() ?? string.Empty;
+        }
+        catch (ObjectDisposedException)
+        {
+            return string.Empty;
+        }
+    }
+
+    public string ToStringAndClear()
+    {
+        try
+        {
+            var builder = GetOrAdd();
+            var value = builder?.ToString();
+
+            builder?.Clear();
+            return value ?? string.Empty;
+        }
+        catch (ObjectDisposedException)
+        {
+            return string.Empty;
+        }
+    }
+
+    private ThreadSafeStringBuilder GetOrAdd()
+    {
+        lock (GlobalSync)
+        {
+            State.Value ??= new();
+
+            if (State.Value!.TryGetValue(_kind, out var builder))
+            {
+                return builder;
+            }
+
+            var newBuilder = new ThreadSafeStringBuilder();
+            State.Value.Add(_kind, newBuilder);
+
+            return newBuilder;
+        }
+    }
+
+    private ThreadSafeStringBuilder? GetOrNull()
+    {
+        lock (GlobalSync)
+        {
+            if (State.Value == null)
+            {
+                return null;
+            }
+
+            return State.Value.TryGetValue(_kind, out var builder) ? builder : null;
+        }
+    }
+}

--- a/src/DrillSergeant.NUnit3/BehaviorAttribute.cs
+++ b/src/DrillSergeant.NUnit3/BehaviorAttribute.cs
@@ -14,7 +14,7 @@ namespace DrillSergeant;
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class BehaviorAttribute : NUnitAttribute, IWrapTestMethod, ISimpleTestBuilder, IApplyToTest, IImplyFixture
 {
-    private readonly NUnitTestCaseBuilder _builder = new ();
+    private readonly NUnitTestCaseBuilder _builder = new();
 
     public string? Feature { get; set; }
 

--- a/src/DrillSergeant.NUnit3/BehaviorCommand.cs
+++ b/src/DrillSergeant.NUnit3/BehaviorCommand.cs
@@ -21,7 +21,7 @@ public class BehaviorCommand : TestCommand
         var method = context.CurrentTest.Method!.MethodInfo;
         var args = context.CurrentTest.Arguments;
 
-        executor.StepFailed += (_, e) => 
+        executor.StepFailed += (_, e) =>
             context.CurrentResult.RecordException(e.Exception, FailureSite.Test);
 
         context.CurrentResult.SetResult(ResultState.Success);

--- a/src/DrillSergeant.Xunit2/BehaviorTestInvoker.cs
+++ b/src/DrillSergeant.Xunit2/BehaviorTestInvoker.cs
@@ -69,7 +69,7 @@ internal class BehaviorTestInvoker : XunitTestInvoker
         var executor = new BehaviorExecutor(_reporter);
         using var behavior = await executor.LoadBehavior(testClassInstance, TestMethod, TestMethodArguments);
         executor.StepFailed += (_, e) => Aggregator.Add(e.Exception);
-        
+
         await executor.Execute(behavior);
     }
 

--- a/src/DrillSergeant/Behavior.cs
+++ b/src/DrillSergeant/Behavior.cs
@@ -47,7 +47,7 @@ public class Behavior : IBehavior
     /// Finalizes an instance of the <see cref="Behavior"/> class.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    ~Behavior() => Dispose(disposing:false);
+    ~Behavior() => Dispose(disposing: false);
 
     /// <inheritdoc cref="IBehavior.Context" />
     public IDictionary<string, object?> Context { get; } = new ExpandoObject();

--- a/src/DrillSergeant/BehaviorExecutor.cs
+++ b/src/DrillSergeant/BehaviorExecutor.cs
@@ -7,7 +7,7 @@ namespace DrillSergeant
 {
     public class BehaviorExecutor
     {
-        public event EventHandler<StepFailedEventArgs> StepFailed = delegate {};
+        public event EventHandler<StepFailedEventArgs> StepFailed = delegate { };
 
         private readonly ITestReporter _reporter;
 
@@ -73,7 +73,7 @@ namespace DrillSergeant
             }
         }
 
-        private static bool IsAsync(MethodInfo method) => 
+        private static bool IsAsync(MethodInfo method) =>
             method.ReturnType.IsAssignableTo(typeof(Task));
 
         private static async Task<decimal> TimedCall(Func<Task> task)

--- a/test/DrillSergeant.Tests.MSTest/BehaviorAttributeTests.cs
+++ b/test/DrillSergeant.Tests.MSTest/BehaviorAttributeTests.cs
@@ -23,7 +23,7 @@ public class BehaviorAttributeTests
         public void NullTypeThrowsTestFailedException()
         {
             // Assert.
-            Assert.ThrowsException<TestFailedException>(() => 
+            Assert.ThrowsException<TestFailedException>(() =>
                 BehaviorAttribute.CreateTestClassInstance(null));
         }
 

--- a/test/DrillSergeant.Tests.MSTest/BehaviorAttributeTests.cs
+++ b/test/DrillSergeant.Tests.MSTest/BehaviorAttributeTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Xml;
+using DrillSergeant.MSTest;
+using Shouldly;
+
+namespace DrillSergeant.Tests.MSTest;
+
+public class BehaviorAttributeTests
+{
+    [TestClass]
+    public class CreateTestClassInstanceMethod : BehaviorAttributeTests
+    {
+        [TestMethod]
+        public void TypeWithEmptyConstructorCreatedSuccessfully()
+        {
+            // Act.
+            var result = BehaviorAttribute.CreateTestClassInstance(typeof(StubWithEmptyCtor));
+
+            // Assert.
+            result.ShouldBeOfType<StubWithEmptyCtor>();
+        }
+
+        [TestMethod]
+        public void NullTypeThrowsTestFailedException()
+        {
+            // Assert.
+            Assert.ThrowsException<TestFailedException>(() => 
+                BehaviorAttribute.CreateTestClassInstance(null));
+        }
+
+        [TestMethod]
+        public void TypeWithNonEmptyCtorThrowsTestFailedException()
+        {
+            // Assert.
+            Assert.ThrowsException<TestFailedException>(() =>
+                BehaviorAttribute.CreateTestClassInstance(typeof(StubWithNonEmptyCtor)));
+        }
+
+        private class StubWithEmptyCtor
+        {
+        }
+
+        private class StubWithNonEmptyCtor
+        {
+            public StubWithNonEmptyCtor(int ignored)
+            {
+            }
+        }
+    }
+}

--- a/test/DrillSergeant.Tests.MSTest/DrillSergeant.Tests.MSTest.csproj
+++ b/test/DrillSergeant.Tests.MSTest/DrillSergeant.Tests.MSTest.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<DefineConstants>NUNIT</DefineConstants>
+		<DefineConstants>MSTEST</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -21,10 +21,14 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Shouldly" Version="4.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>
+	  <ProjectReference Include="..\..\src\DrillSergeant.MSTest\DrillSergeant.MSTest.csproj" />
 	  <ProjectReference Include="..\..\src\DrillSergeant\DrillSergeant.csproj" />
 	</ItemGroup>
+
+	<Import Project="..\DrillSergeant.Tests.Shared\DrillSergeant.Tests.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/test/DrillSergeant.Tests.MSTest/DrillSergeant.Tests.MSTest.csproj
+++ b/test/DrillSergeant.Tests.MSTest/DrillSergeant.Tests.MSTest.csproj
@@ -29,4 +29,6 @@
 	  <ProjectReference Include="..\..\src\DrillSergeant\DrillSergeant.csproj" />
 	</ItemGroup>
 
+	<Import Project="..\DrillSergeant.Tests.Shared\DrillSergeant.Tests.Shared.projitems" Label="Shared" />
+
 </Project>

--- a/test/DrillSergeant.Tests.MSTest/DrillSergeant.Tests.MSTest.csproj
+++ b/test/DrillSergeant.Tests.MSTest/DrillSergeant.Tests.MSTest.csproj
@@ -29,6 +29,4 @@
 	  <ProjectReference Include="..\..\src\DrillSergeant\DrillSergeant.csproj" />
 	</ItemGroup>
 
-	<Import Project="..\DrillSergeant.Tests.Shared\DrillSergeant.Tests.Shared.projitems" Label="Shared" />
-
 </Project>

--- a/test/DrillSergeant.Tests.MSTest/DrillSergeant.Tests.MSTest.csproj
+++ b/test/DrillSergeant.Tests.MSTest/DrillSergeant.Tests.MSTest.csproj
@@ -14,6 +14,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="FakeItEasy" Version="7.4.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
 		<PackageReference Include="MSTest.TestFramework" Version="3.0.4" />

--- a/test/DrillSergeant.Tests.MSTest/DrillSergeant.Tests.MSTest.csproj
+++ b/test/DrillSergeant.Tests.MSTest/DrillSergeant.Tests.MSTest.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<DefineConstants>NUNIT</DefineConstants>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\src\DrillSergeant\DrillSergeant.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/test/DrillSergeant.Tests.MSTest/ObjectExtensionsTests.cs
+++ b/test/DrillSergeant.Tests.MSTest/ObjectExtensionsTests.cs
@@ -12,17 +12,17 @@ public class ObjectExtensionsTests
     [ClassInitialize]
     public static void Init(TestContext context) => MyContext = context;
 
-    [Behavior]
-    public void MyBehavior()
-    {
-        Console.Out.WriteLine("OUT LINE");
-        MyContext?.WriteLine("FOO");
-        Console.Error.WriteLine("ERR LINE");
-        Trace.WriteLine("TRACE LINE");
-        Trace.WriteLine("TRACE LINE2");
-        Debug.WriteLine("DEBUG LINE");
-        Debug.WriteLine("DEBUG LINE2");
-    }
+    //[Behavior]
+    //public void MyBehavior()
+    //{
+    //    Console.Out.WriteLine("OUT LINE");
+    //    MyContext?.WriteLine("FOO");
+    //    Console.Error.WriteLine("ERR LINE");
+    //    Trace.WriteLine("TRACE LINE");
+    //    Trace.WriteLine("TRACE LINE2");
+    //    Debug.WriteLine("DEBUG LINE");
+    //    Debug.WriteLine("DEBUG LINE2");
+    //}
 
 
     [TestClass]

--- a/test/DrillSergeant.Tests.MSTest/ObjectExtensionsTests.cs
+++ b/test/DrillSergeant.Tests.MSTest/ObjectExtensionsTests.cs
@@ -1,0 +1,43 @@
+﻿using DrillSergeant.MSTest;
+using Shouldly;
+
+namespace DrillSergeant.Tests.MSTest;
+
+[TestClass]
+public class ObjectExtensionsTests
+{
+
+    [TestMethod]
+    public void UnknownPropertyReturnsNull()
+    {
+        // Arrange.
+        var stub = new StubWithPrivateProperties();
+
+        // Act.
+        var result = stub.GetPrivateProperty("unknown");
+
+        // Assert.
+        result.ShouldBeNull();
+    }
+
+    [TestMethod]
+    public void KnownPropertyReturnsPropertyValue()
+    {
+        // Arrange.
+        var stub = new StubWithPrivateProperties();
+        var expected = stub.PrivatePropertyValue();
+
+        // Act.
+        var result = stub.GetPrivateProperty("PrivateProperty");
+
+        // Assert.
+        result.ShouldBeSameAs(expected);
+    }
+
+    public class StubWithPrivateProperties
+    {
+        public object PrivatePropertyValue() => PrivateProperty;
+
+        private object PrivateProperty { get; set; } = new object();
+    }
+}

--- a/test/DrillSergeant.Tests.MSTest/ObjectExtensionsTests.cs
+++ b/test/DrillSergeant.Tests.MSTest/ObjectExtensionsTests.cs
@@ -16,7 +16,7 @@ public class ObjectExtensionsTests
     public void MyBehavior()
     {
         Console.Out.WriteLine("OUT LINE");
-        MyContext.WriteLine("FOO");
+        MyContext?.WriteLine("FOO");
         Console.Error.WriteLine("ERR LINE");
         Trace.WriteLine("TRACE LINE");
         Trace.WriteLine("TRACE LINE2");

--- a/test/DrillSergeant.Tests.MSTest/ObjectExtensionsTests.cs
+++ b/test/DrillSergeant.Tests.MSTest/ObjectExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using DrillSergeant.MSTest;
+﻿using System.Diagnostics;
+using DrillSergeant.MSTest;
 using Shouldly;
 
 namespace DrillSergeant.Tests.MSTest;
@@ -6,38 +7,117 @@ namespace DrillSergeant.Tests.MSTest;
 [TestClass]
 public class ObjectExtensionsTests
 {
+    public static TestContext? MyContext;
 
-    [TestMethod]
-    public void UnknownPropertyReturnsNull()
+    [ClassInitialize]
+    public static void Init(TestContext context) => MyContext = context;
+
+    [Behavior]
+    public void MyBehavior()
     {
-        // Arrange.
-        var stub = new StubWithPrivateProperties();
-
-        // Act.
-        var result = stub.GetPrivateProperty("unknown");
-
-        // Assert.
-        result.ShouldBeNull();
+        Console.Out.WriteLine("OUT LINE");
+        MyContext.WriteLine("FOO");
+        Console.Error.WriteLine("ERR LINE");
+        Trace.WriteLine("TRACE LINE");
+        Trace.WriteLine("TRACE LINE2");
+        Debug.WriteLine("DEBUG LINE");
+        Debug.WriteLine("DEBUG LINE2");
     }
 
-    [TestMethod]
-    public void KnownPropertyReturnsPropertyValue()
+
+    [TestClass]
+    public class GetPrivatePropertyMethod : ObjectExtensionsTests
     {
-        // Arrange.
-        var stub = new StubWithPrivateProperties();
-        var expected = stub.PrivatePropertyValue();
+        [TestMethod]
+        public void UnknownPropertyReturnsNull()
+        {
+            // Arrange.
+            var stub = new StubWithPrivateProperties();
 
-        // Act.
-        var result = stub.GetPrivateProperty("PrivateProperty");
+            // Act.
+            var result = stub.GetPrivateProperty("unknown");
 
-        // Assert.
-        result.ShouldBeSameAs(expected);
+            // Assert.
+            result.ShouldBeNull();
+        }
+
+        [TestMethod]
+        public void KnownPropertyReturnsPropertyValue()
+        {
+            // Arrange.
+            var stub = new StubWithPrivateProperties();
+            var expected = stub.PrivatePropertyValue();
+
+            // Act.
+            var result = stub.GetPrivateProperty("PrivateProperty");
+
+            // Assert.
+            result.ShouldBeSameAs(expected);
+        }
+
+        private class StubWithPrivateProperties
+        {
+            public object PrivatePropertyValue() => PrivateProperty;
+
+            private object PrivateProperty { get; set; } = new object();
+        }
     }
 
-    public class StubWithPrivateProperties
+    [TestClass]
+    public class CoerceCastMethod : ObjectExtensionsTests
     {
-        public object PrivatePropertyValue() => PrivateProperty;
+        [TestMethod]
+        public void BindsMatchingType()
+        {
+            // Arrange.
+            var source = new StubTypeSource
+            {
+                IntProperty = 1
+            };
 
-        private object PrivateProperty { get; set; } = new object();
+            // Act.
+            var result = source.CoerceCast<StubTypeTarget>();
+
+            // Assert.
+            result.IntProperty.ShouldBe(1);
+        }
+
+        [TestMethod]
+        public void BindsPropertyWithCommonRoot()
+        {
+            // Arrange.
+            var source = new StubTypeSource
+            {
+                Stub = new StubImplementation()
+            };
+
+            // Act.
+            var result = source.CoerceCast<StubTypeTarget>();
+
+            // Assert.
+            result.Stub.ShouldNotBeNull();
+        }
+
+        private interface IStub
+        {
+        }
+
+        private class StubImplementation : IStub
+        {
+        }
+
+        private class StubTypeSource
+        {
+            public int IntProperty { get; set; }
+
+            public IStub? Stub { get; set; }
+        }
+
+        private class StubTypeTarget
+        {
+            public int IntProperty { get; set; }
+
+            public StubImplementation? Stub { get; set; }
+        }
     }
 }

--- a/test/DrillSergeant.Tests.MSTest/ThreadSafeStringWriterTests.cs
+++ b/test/DrillSergeant.Tests.MSTest/ThreadSafeStringWriterTests.cs
@@ -1,0 +1,39 @@
+﻿using DrillSergeant.MSTest;
+using Shouldly;
+using System.Globalization;
+
+namespace DrillSergeant.Tests.MSTest;
+
+[TestClass]
+public class ThreadSafeStringWriterTests
+{
+    [TestMethod]
+    public void ToStringReturnsCurrentContents()
+    {
+        // Arrange.
+        var writer = new ThreadSafeStringWriter(CultureInfo.InvariantCulture, "ignored");
+
+        // Act.
+        writer.WriteLine("test");
+        var result = writer.ToString();
+
+        // Assert.
+        result.ShouldStartWith("test"); // WriteLine() adds a newline.
+    }
+
+    [TestMethod]
+    public void ToStringAndClearClearsWriter()
+    {
+        // Arrange.
+        var writer = new ThreadSafeStringWriter(CultureInfo.InvariantCulture, "ignored");
+
+        // Act.
+        writer.WriteLine("test");
+        var expectedText = writer.ToStringAndClear();
+        var emptyText = writer.ToString();
+
+        // Assert.
+        expectedText.ShouldNotBeEmpty();
+        emptyText.ShouldBeEmpty();
+    }
+}

--- a/test/DrillSergeant.Tests.MSTest/Usings.cs
+++ b/test/DrillSergeant.Tests.MSTest/Usings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/DrillSergeant.Tests.Shared/Features/AsyncVariationsFeature.cs
+++ b/test/DrillSergeant.Tests.Shared/Features/AsyncVariationsFeature.cs
@@ -3,6 +3,9 @@ using Shouldly;
 
 namespace DrillSergeant.Tests.Features;
 
+#if MSTEST
+[TestClass]
+#endif
 public class AsyncVariationsFeature
 {
     public class Context
@@ -26,6 +29,9 @@ public class AsyncVariationsFeature
     }
 
     [Behavior]
+#if MSTEST
+    [TestCategory("SAMPLE_CAT")]
+#endif
     public void WaitUsingInlineDelay_WithContext()
     {
         BehaviorBuilder.New()

--- a/test/DrillSergeant.Tests.Shared/Features/BaseStepFeature.cs
+++ b/test/DrillSergeant.Tests.Shared/Features/BaseStepFeature.cs
@@ -3,6 +3,9 @@ using Shouldly;
 
 namespace DrillSergeant.Tests.Features;
 
+#if MSTEST
+[TestClass]
+#endif
 public class BaseStepFeature
 {
     [Behavior]

--- a/test/DrillSergeant.Tests.Shared/Features/CalculatorFeature.cs
+++ b/test/DrillSergeant.Tests.Shared/Features/CalculatorFeature.cs
@@ -12,6 +12,9 @@ using Xunit.Abstractions;
 
 namespace DrillSergeant.Tests.Features;
 
+#if MSTEST
+[TestClass]
+#endif
 public class CalculatorFeature
 {
 #if XUNIT
@@ -40,6 +43,7 @@ public class CalculatorFeature
         };
     }
 
+#if !MSTEST // AutoFixture does not support MSTest.
     [Behavior(Feature = "Calculator")]
     [InlineAutoData]
     [InlineAutoData]
@@ -59,6 +63,7 @@ public class CalculatorFeature
             .When(AddNumbers(_calculator))
             .Then<CheckResultStep>();
     }
+#endif
 
     [Behavior]
 #if XUNIT
@@ -66,6 +71,9 @@ public class CalculatorFeature
 #endif
 #if NUNIT
     [TestCaseSource(nameof(AdditionInputs))]
+#endif
+#if MSTEST
+    [DynamicData(nameof(AdditionInputs))]
 #endif
     public void AsyncAdditionBehavior(int a, int b, int expected)
     {
@@ -89,6 +97,9 @@ public class CalculatorFeature
 #endif
 #if NUNIT
     [TestCaseSource(nameof(AdditionInputs))]
+#endif
+#if MSTEST
+    [DynamicData(nameof(AdditionInputs))]
 #endif
     public void AdditionBehavior(int a, int b, int expected)
     {

--- a/test/DrillSergeant.Tests/BehaviorTests.cs
+++ b/test/DrillSergeant.Tests/BehaviorTests.cs
@@ -27,7 +27,7 @@ public class BehaviorTests
         {
             // Arrange.
             var obj = new StepWithDispose();
-            var behavior = 
+            var behavior =
                 new Behavior()
                     .Owns(obj);
 
@@ -43,7 +43,7 @@ public class BehaviorTests
         {
             // Arrange.
             var obj = new StepWithDispose();
-            var background = 
+            var background =
                 new Behavior()
                     .Owns(obj);
 


### PR DESCRIPTION
Experimental support for MSTest Added.  Able to successfully run all behaviors along with unit tests.

Required several major hacks by using reflection to reach into the MSTest object trees since many of them are hidden behind `private` and `internal` accessors.  Also needed to port/copy their stream management code in order to support capture and reporting.

Will add more tests later.  It works, but it's definitely not production-grade.