### PR TITLE
Added support for short-hand records in context/input.

### DIFF
--- a/src/DrillSergeant/ReflectionParameterCaster.cs
+++ b/src/DrillSergeant/ReflectionParameterCaster.cs
@@ -43,8 +43,8 @@ public class ReflectionParameterCaster : IParameterCaster
         var target = ctor.Invoke(ctorArguments)!;
 
         foreach (var property in from p in properties
-                 where source.ContainsKey(p.Name)
-                 select p)
+                                 where source.ContainsKey(p.Name)
+                                 select p)
         {
             var value = source[property.Name]!;
 

--- a/test/DrillSergeant.Tests.Shared/Features/CalculatorFeature.cs
+++ b/test/DrillSergeant.Tests.Shared/Features/CalculatorFeature.cs
@@ -22,12 +22,8 @@ public class CalculatorFeature
 #endif
     private readonly Calculator _calculator = new();
 
-    public record Input
-    {
-        public int A { get; init; }
-        public int B { get; init; }
-        public int Expected { get; init; }
-    }
+    public record Input(int A, int B, int Expected);
+
 
 #if XUNIT
     public CalculatorFeature(ITestOutputHelper outputHelper) => _outputHelper = outputHelper;
@@ -49,12 +45,7 @@ public class CalculatorFeature
     [InlineAutoData]
     public void AdditionBehaviorWithAutoData(int a, int b)
     {
-        var input = new Input
-        {
-            A = a,
-            B = b,
-            Expected = a + b
-        };
+        var input = new Input(a, b, a + b);
 
         BehaviorBuilder.New(input)
             .EnableContextLogging()
@@ -77,12 +68,7 @@ public class CalculatorFeature
 #endif
     public void AsyncAdditionBehavior(int a, int b, int expected)
     {
-        var input = new Input
-        {
-            A = a,
-            B = b,
-            Expected = expected
-        };
+        var input = new Input(a, b, expected);
 
         BehaviorBuilder.New(input)
             .Given("Set first number", (c, i) => c.A = i.A)
@@ -103,12 +89,7 @@ public class CalculatorFeature
 #endif
     public void AdditionBehavior(int a, int b, int expected)
     {
-        var input = new Input
-        {
-            A = a,
-            B = b,
-            Expected = expected
-        };
+        var input = new Input(a, b, expected);
 
         BehaviorBuilder.New(input)
             .EnableContextLogging()
@@ -130,10 +111,7 @@ public class CalculatorFeature
     // Step implemented as a lambda step for greater flexibility.
     public LambdaStep AddNumbers(Calculator calculator) =>
         new LambdaStep("Add numbers")
-            .Handle((c) =>
-            {
-                c.Result = calculator.Add(c.A, c.B);
-            });
+            .Handle((c) => { c.Result = calculator.Add(c.A, c.B); });
 
     public LambdaStep AddNumbersAsync(Calculator calculator) =>
         new LambdaStep("Add numbers")

--- a/test/DrillSergeant.Tests/ReflectionParameterCasterTests.cs
+++ b/test/DrillSergeant.Tests/ReflectionParameterCasterTests.cs
@@ -41,6 +41,28 @@ public class ReflectionParameterCasterTests
     public class InstantiateInstanceMethod : ReflectionParameterCasterTests
     {
         [Fact]
+        public void NoPublicConstructorsThrowsInvalidOperationException()
+        {
+            // Arrange.
+            var source = new Dictionary<string, object?>();
+
+            // Assert.
+            Assert.Throws<InvalidOperationException>(() =>
+                ReflectionParameterCaster.InstantiateInstance(source, typeof(ClassWithoutPublicConstructors)));
+        }
+
+        [Fact]
+        public void MultipleConstructorsThrowsInvalidOperationException()
+        {
+            // Arrange.
+            var source = new Dictionary<string, object?>();
+
+            // Assert.
+            Assert.Throws<InvalidOperationException>(() =>
+                ReflectionParameterCaster.InstantiateInstance(source, typeof(ClassWithMultipleConstructors)));
+        }
+
+        [Fact]
         public void InstantiatesRecordWithParameters()
         {
             // Arrange.
@@ -108,6 +130,23 @@ public class ReflectionParameterCasterTests
         }
 
         [Fact]
+        public void MisMatchedTypesAreIgnoredOnConstructor()
+        {
+            // Arrange.
+            var source = new Dictionary<string, object?>
+            {
+                ["IntValue"] = 1,
+                ["StringValue"] = 1
+            };
+
+            // Act.
+            var result = (RecordWithOptionalParameters)ReflectionParameterCaster.InstantiateInstance(source, typeof(RecordWithOptionalParameters));
+
+            // Assert.
+            result.StringValue.ShouldBeNull();
+        }
+
+        [Fact]
         public void MatchingSupportsCovariantTypes()
         {
             // Arrange.
@@ -166,6 +205,26 @@ public class ReflectionParameterCasterTests
             public StubBaseType? CovariantTypeValue { get; init; }
             public StubDerivedType? ContravariantTypeValue { get; init; }
         }
+
+        public class ClassWithoutPublicConstructors
+        {
+            protected ClassWithoutPublicConstructors()
+            {
+                
+            }
+        }
+
+        public class ClassWithMultipleConstructors
+        {
+            public ClassWithMultipleConstructors()
+            {
+            }
+
+            public ClassWithMultipleConstructors(int ignored)
+            {
+            }
+        }
+
 
         public class StubBaseType { }
         public class StubDerivedType : StubBaseType { }

--- a/test/DrillSergeant.Tests/ReflectionParameterCasterTests.cs
+++ b/test/DrillSergeant.Tests/ReflectionParameterCasterTests.cs
@@ -7,140 +7,275 @@ namespace DrillSergeant.Tests;
 
 public class ReflectionParameterCasterTests
 {
-    [Fact]
-    public void NoConversionIsPerformedWhenRawObjectIsPassed()
+    public class CastMethod : ReflectionParameterCasterTests
     {
-        // Arrange.
-        var caster = new ReflectionParameterCaster();
-        var source = new Dictionary<string, object?>();
-
-        // Act.
-        var result = caster.Cast(source, typeof(object));
-
-        // Assert.
-        result.ShouldBeSameAs(source);
-    }
-
-    [Theory]
-    [InlineData(typeof(int))]
-    [InlineData(typeof(string))]
-    [InlineData(typeof(int[]))]
-    public void CastingToPrimitiveThrowsInvalidOperationException(Type type)
-    {
-        // Arrange.
-        var caster = new ReflectionParameterCaster();
-        var source = new Dictionary<string, object?>();
-
-        // Assert.
-        Assert.Throws<InvalidOperationException>(() => caster.Cast(source, type));
-    }
-
-    [Fact]
-    public void ThrowsInvalidOperationExceptionIfTypeDoesNotContainParameterlessConstructor()
-    {
-        // Arrange.
-        var caster = new ReflectionParameterCaster();
-        var source = new Dictionary<string, object?>();
-
-        // Assert.
-        Assert.Throws<InvalidOperationException>(() => caster.Cast(source, typeof(TargetWithoutEmptyConstructor)));
-    }
-
-    [Fact]
-    public void MatchingTypesAreMappedAutomatically()
-    {
-        // Arrange.
-        var caster = new ReflectionParameterCaster();
-        var source = new Dictionary<string, object?>
+        [Fact]
+        public void NoConversionIsPerformedWhenRawObjectIsPassed()
         {
-            ["IntValue"] = 1
-        };
+            // Arrange.
+            var caster = new ReflectionParameterCaster();
+            var source = new Dictionary<string, object?>();
 
-        // Act.
-        var result = (TargetWithParameters)caster.Cast(source, typeof(TargetWithParameters));
+            // Act.
+            var result = caster.Cast(source, typeof(object));
 
-        // Assert.
-        result.IntValue.ShouldBe(1);
-    }
+            // Assert.
+            result.ShouldBeSameAs(source);
+        }
 
-    [Fact]
-    public void MisMatchedTypesAreIgnoredWhenMapping()
-    {
-        // Arrange.
-        var caster = new ReflectionParameterCaster();
-        var source = new Dictionary<string, object?>
+        [Theory]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int[]))]
+        public void CastingToPrimitiveThrowsInvalidOperationException(Type type)
         {
-            ["StringValue"] = 1
-        };
+            // Arrange.
+            var caster = new ReflectionParameterCaster();
+            var source = new Dictionary<string, object?>();
 
-        // Act.
-        var result = (TargetWithParameters)caster.Cast(source, typeof(TargetWithParameters));
-
-        // Assert.
-        result.StringValue.ShouldBeNull();
+            // Assert.
+            Assert.Throws<InvalidOperationException>(() => caster.Cast(source, type));
+        }
     }
 
-    [Fact]
-    public void MatchingSupportsCovariantTypes()
+    public class InstantiateClassMethod : ReflectionParameterCasterTests
     {
-        // Arrange.
-        var caster = new ReflectionParameterCaster();
-        var source = new Dictionary<string, object?>
+        [Fact]
+        public void ThrowsInvalidOperationExceptionIfTypeDoesNotContainAnEmptyConstructor()
         {
-            ["CovariantTypeValue"] = new StubDerivedType()
-        };
+            // Arrange.
+            var source = new Dictionary<string, object?>();
 
-        // Act.
-        var result = (TargetWithParameters)caster.Cast(source, typeof(TargetWithParameters));
+            // Assert.
+            Assert.Throws<InvalidOperationException>(
+                () => ReflectionParameterCaster.InstantiateClass(source, typeof(TargetWithoutEmptyConstructor)));
+        }
 
-        // Assert.
-        result.CovariantTypeValue.ShouldNotBeNull();
-    }
-
-    [Fact]
-    public void MatchingDoesNotSupportContravariantTypes()
-    {
-        // Arrange.
-        var caster = new ReflectionParameterCaster();
-        var source = new Dictionary<string, object?>
+        [Fact]
+        public void MatchingTypesAreMappedAutomatically()
         {
-            ["ContravariantTypeValue"] = new StubBaseType()
-        };
+            // Arrange.
+            var caster = new ReflectionParameterCaster();
+            var source = new Dictionary<string, object?>
+            {
+                ["IntValue"] = 1
+            };
 
-        // Act.
-        var result = (TargetWithParameters)caster.Cast(source, typeof(TargetWithParameters));
+            // Act.
+            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateClass(source, typeof(TargetWithParameters));
 
-        // Assert.
-        result.CovariantTypeValue.ShouldBeNull();
-    }
+            // Assert.
+            result.IntValue.ShouldBe(1);
+        }
 
-    [Fact]
-    public void NullPropertyIsUnset()
-    {
-        // Arrange.
-        var caster = new ReflectionParameterCaster();
-        var source = new Dictionary<string, object?>
+        [Fact]
+        public void MisMatchedTypesAreIgnoredWhenMapping()
         {
-            ["StringValue"] = null
-        };
+            // Arrange.
+            var caster = new ReflectionParameterCaster();
+            var source = new Dictionary<string, object?>
+            {
+                ["StringValue"] = 1
+            };
 
-        // Act.
-        var result = (TargetWithParameters)caster.Cast(source, typeof(TargetWithParameters));
+            // Act.
+            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateClass(source, typeof(TargetWithParameters));
 
-        // Assert.
-        result.CovariantTypeValue.ShouldBeNull();
+            // Assert.
+            result.StringValue.ShouldBeNull();
+        }
+
+        [Fact]
+        public void MatchingSupportsCovariantTypes()
+        {
+            // Arrange.
+            var caster = new ReflectionParameterCaster();
+            var source = new Dictionary<string, object?>
+            {
+                ["CovariantTypeValue"] = new StubDerivedType()
+            };
+
+            // Act.
+            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateClass(source, typeof(TargetWithParameters));
+
+            // Assert.
+            result.CovariantTypeValue.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void MatchingDoesNotSupportContravariantTypes()
+        {
+            // Arrange.
+            var caster = new ReflectionParameterCaster();
+            var source = new Dictionary<string, object?>
+            {
+                ["ContravariantTypeValue"] = new StubBaseType()
+            };
+
+            // Act.
+            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateClass(source, typeof(TargetWithParameters));
+
+            // Assert.
+            result.CovariantTypeValue.ShouldBeNull();
+        }
+
+        [Fact]
+        public void NullPropertyIsUnset()
+        {
+            // Arrange.
+            var caster = new ReflectionParameterCaster();
+            var source = new Dictionary<string, object?>
+            {
+                ["StringValue"] = null
+            };
+
+            // Act.
+            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateClass(source, typeof(TargetWithParameters));
+
+            // Assert.
+            result.CovariantTypeValue.ShouldBeNull();
+        }
+
+        public record TargetWithoutEmptyConstructor(int Ignored);
+
+        public class TargetWithParameters
+        {
+            public int IntValue { get; init; }
+            public string? StringValue { get; init; }
+            public StubBaseType? CovariantTypeValue { get; init; }
+            public StubDerivedType? ContravariantTypeValue { get; init; }
+        }
+
+        public class StubBaseType { }
+        public class StubDerivedType : StubBaseType { }
     }
 
-    public record TargetWithoutEmptyConstructor(int Ignored);
-
-    public record TargetWithParameters
+    public class InstantiateRecordMethod : ReflectionParameterCasterTests
     {
-        public int IntValue { get; init; }
-        public string? StringValue { get; init; }
-        public StubBaseType? CovariantTypeValue { get; init; }
-        public StubDerivedType? ContravariantTypeValue { get; init; }
+        [Fact]
+        public void InstantiatesRecordWithParameters()
+        {
+            // Arrange.
+            var source = new Dictionary<string, object?>
+            {
+                ["IntValue"] = 1,
+                ["StringValue"] = "expected"
+            };
+
+            // Act.
+            var result = (RecordWithParameters)ReflectionParameterCaster.InstantiateRecord(source, typeof(RecordWithParameters));
+
+            // Assert.
+            result.IntValue.ShouldBe(1);
+            result.StringValue.ShouldBe("expected");
+        }
+
+        [Fact]
+        public void SkipsMissingParametersInSource()
+        {
+            // Arrange.
+            var source = new Dictionary<string, object?>
+            {
+                ["IntValue"] = 1,
+            };
+
+            // Act.
+            var result = (RecordWithOptionalParameters)ReflectionParameterCaster.InstantiateRecord(source, typeof(RecordWithOptionalParameters));
+
+            // Assert.
+            result.IntValue.ShouldBe(1);
+            result.StringValue.ShouldBeNull();
+        }
+
+        [Fact]
+        public void MatchingSupportsCovariantTypes()
+        {
+            // Arrange.
+            var source = new Dictionary<string, object?>
+            {
+                ["CovariantTypeValue"] = new StubDerivedType()
+            };
+
+            // Act.
+            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateRecord(source, typeof(TargetWithParameters));
+
+            // Assert.
+            result.CovariantTypeValue.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void MatchingDoesNotSupportContravariantTypes()
+        {
+            // Arrange.
+            var source = new Dictionary<string, object?>
+            {
+                ["ContravariantTypeValue"] = new StubBaseType()
+            };
+
+            // Act.
+            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateRecord(source, typeof(TargetWithParameters));
+
+            // Assert.
+            result.CovariantTypeValue.ShouldBeNull();
+        }
+
+
+        public record RecordWithParameters(int IntValue, string StringValue);
+        
+        public record RecordWithOptionalParameters(int IntValue, string? StringValue);
+
+        public record TargetWithParameters(
+            int IntValue,
+            string? StringValue,
+            StubBaseType? CovariantTypeValue,
+            StubDerivedType? ContravariantTypeValue);
+
+        public record StubBaseType { }
+        public record StubDerivedType : StubBaseType { }
     }
 
-    public class StubBaseType { }
-    public class StubDerivedType : StubBaseType { }
+    public class IsRecordMethod : ReflectionParameterCasterTests
+    {
+        [Theory]
+        [InlineData(typeof(CompleteRecord))]
+        [InlineData(typeof(PartialRecord))]
+        public void ValidScenarios(Type type)
+        {
+            // Act.
+            bool result = ReflectionParameterCaster.IsRecord(type);
+
+            // Assert.
+            result.ShouldBeTrue();
+        }
+
+        [Theory]
+        [InlineData(typeof(EmptyRecord))]
+        [InlineData(typeof(NonRecord))]
+        public void InvalidScenarios(Type type)
+        {            
+            // Act.
+            bool result = ReflectionParameterCaster.IsRecord(type);
+
+            // Assert.
+            result.ShouldBeFalse();
+        }
+
+        public record CompleteRecord(int IntValue, string StringValue);
+
+        public record PartialRecord(int IntValue)
+        {
+            public string? StringValue { get; init; }
+        }
+
+        public record EmptyRecord();
+
+        public class NonRecord
+        {
+            public NonRecord(string stringValue)
+            {
+            }
+
+            public int IntValue { get; set; }
+        }
+    }
 }

--- a/test/DrillSergeant.Tests/ReflectionParameterCasterTests.cs
+++ b/test/DrillSergeant.Tests/ReflectionParameterCasterTests.cs
@@ -38,119 +38,7 @@ public class ReflectionParameterCasterTests
         }
     }
 
-    public class InstantiateClassMethod : ReflectionParameterCasterTests
-    {
-        [Fact]
-        public void ThrowsInvalidOperationExceptionIfTypeDoesNotContainAnEmptyConstructor()
-        {
-            // Arrange.
-            var source = new Dictionary<string, object?>();
-
-            // Assert.
-            Assert.Throws<InvalidOperationException>(
-                () => ReflectionParameterCaster.InstantiateClass(source, typeof(TargetWithoutEmptyConstructor)));
-        }
-
-        [Fact]
-        public void MatchingTypesAreMappedAutomatically()
-        {
-            // Arrange.
-            var caster = new ReflectionParameterCaster();
-            var source = new Dictionary<string, object?>
-            {
-                ["IntValue"] = 1
-            };
-
-            // Act.
-            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateClass(source, typeof(TargetWithParameters));
-
-            // Assert.
-            result.IntValue.ShouldBe(1);
-        }
-
-        [Fact]
-        public void MisMatchedTypesAreIgnoredWhenMapping()
-        {
-            // Arrange.
-            var caster = new ReflectionParameterCaster();
-            var source = new Dictionary<string, object?>
-            {
-                ["StringValue"] = 1
-            };
-
-            // Act.
-            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateClass(source, typeof(TargetWithParameters));
-
-            // Assert.
-            result.StringValue.ShouldBeNull();
-        }
-
-        [Fact]
-        public void MatchingSupportsCovariantTypes()
-        {
-            // Arrange.
-            var caster = new ReflectionParameterCaster();
-            var source = new Dictionary<string, object?>
-            {
-                ["CovariantTypeValue"] = new StubDerivedType()
-            };
-
-            // Act.
-            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateClass(source, typeof(TargetWithParameters));
-
-            // Assert.
-            result.CovariantTypeValue.ShouldNotBeNull();
-        }
-
-        [Fact]
-        public void MatchingDoesNotSupportContravariantTypes()
-        {
-            // Arrange.
-            var caster = new ReflectionParameterCaster();
-            var source = new Dictionary<string, object?>
-            {
-                ["ContravariantTypeValue"] = new StubBaseType()
-            };
-
-            // Act.
-            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateClass(source, typeof(TargetWithParameters));
-
-            // Assert.
-            result.CovariantTypeValue.ShouldBeNull();
-        }
-
-        [Fact]
-        public void NullPropertyIsUnset()
-        {
-            // Arrange.
-            var caster = new ReflectionParameterCaster();
-            var source = new Dictionary<string, object?>
-            {
-                ["StringValue"] = null
-            };
-
-            // Act.
-            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateClass(source, typeof(TargetWithParameters));
-
-            // Assert.
-            result.CovariantTypeValue.ShouldBeNull();
-        }
-
-        public record TargetWithoutEmptyConstructor(int Ignored);
-
-        public class TargetWithParameters
-        {
-            public int IntValue { get; init; }
-            public string? StringValue { get; init; }
-            public StubBaseType? CovariantTypeValue { get; init; }
-            public StubDerivedType? ContravariantTypeValue { get; init; }
-        }
-
-        public class StubBaseType { }
-        public class StubDerivedType : StubBaseType { }
-    }
-
-    public class InstantiateRecordMethod : ReflectionParameterCasterTests
+    public class InstantiateInstanceMethod : ReflectionParameterCasterTests
     {
         [Fact]
         public void InstantiatesRecordWithParameters()
@@ -163,7 +51,7 @@ public class ReflectionParameterCasterTests
             };
 
             // Act.
-            var result = (RecordWithParameters)ReflectionParameterCaster.InstantiateRecord(source, typeof(RecordWithParameters));
+            var result = (RecordWithParameters)ReflectionParameterCaster.InstantiateInstance(source, typeof(RecordWithParameters));
 
             // Assert.
             result.IntValue.ShouldBe(1);
@@ -180,10 +68,42 @@ public class ReflectionParameterCasterTests
             };
 
             // Act.
-            var result = (RecordWithOptionalParameters)ReflectionParameterCaster.InstantiateRecord(source, typeof(RecordWithOptionalParameters));
+            var result = (RecordWithOptionalParameters)ReflectionParameterCaster.InstantiateInstance(source, typeof(RecordWithOptionalParameters));
 
             // Assert.
             result.IntValue.ShouldBe(1);
+            result.StringValue.ShouldBeNull();
+        }
+
+        [Fact]
+        public void MatchingTypesAreMappedAutomatically()
+        {
+            // Arrange.
+            var source = new Dictionary<string, object?>
+            {
+                ["IntValue"] = 1
+            };
+
+            // Act.
+            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateInstance(source, typeof(TargetWithParameters));
+
+            // Assert.
+            result.IntValue.ShouldBe(1);
+        }
+
+        [Fact]
+        public void MisMatchedTypesAreIgnoredWhenMapping()
+        {
+            // Arrange.
+            var source = new Dictionary<string, object?>
+            {
+                ["StringValue"] = 1
+            };
+
+            // Act.
+            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateInstance(source, typeof(TargetWithParameters));
+
+            // Assert.
             result.StringValue.ShouldBeNull();
         }
 
@@ -197,7 +117,7 @@ public class ReflectionParameterCasterTests
             };
 
             // Act.
-            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateRecord(source, typeof(TargetWithParameters));
+            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateInstance(source, typeof(TargetWithParameters));
 
             // Assert.
             result.CovariantTypeValue.ShouldNotBeNull();
@@ -213,69 +133,41 @@ public class ReflectionParameterCasterTests
             };
 
             // Act.
-            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateRecord(source, typeof(TargetWithParameters));
+            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateInstance(source, typeof(TargetWithParameters));
 
             // Assert.
             result.CovariantTypeValue.ShouldBeNull();
         }
 
+        [Fact]
+        public void NullPropertyIsUnset()
+        {
+            // Arrange.
+            var source = new Dictionary<string, object?>
+            {
+                ["StringValue"] = null
+            };
+
+            // Act.
+            var result = (TargetWithParameters)ReflectionParameterCaster.InstantiateInstance(source, typeof(TargetWithParameters));
+
+            // Assert.
+            result.CovariantTypeValue.ShouldBeNull();
+        }
 
         public record RecordWithParameters(int IntValue, string StringValue);
-        
+
         public record RecordWithOptionalParameters(int IntValue, string? StringValue);
 
-        public record TargetWithParameters(
-            int IntValue,
-            string? StringValue,
-            StubBaseType? CovariantTypeValue,
-            StubDerivedType? ContravariantTypeValue);
-
-        public record StubBaseType { }
-        public record StubDerivedType : StubBaseType { }
-    }
-
-    public class IsRecordMethod : ReflectionParameterCasterTests
-    {
-        [Theory]
-        [InlineData(typeof(CompleteRecord))]
-        [InlineData(typeof(PartialRecord))]
-        public void ValidScenarios(Type type)
+        public class TargetWithParameters
         {
-            // Act.
-            bool result = ReflectionParameterCaster.IsRecord(type);
-
-            // Assert.
-            result.ShouldBeTrue();
-        }
-
-        [Theory]
-        [InlineData(typeof(EmptyRecord))]
-        [InlineData(typeof(NonRecord))]
-        public void InvalidScenarios(Type type)
-        {            
-            // Act.
-            bool result = ReflectionParameterCaster.IsRecord(type);
-
-            // Assert.
-            result.ShouldBeFalse();
-        }
-
-        public record CompleteRecord(int IntValue, string StringValue);
-
-        public record PartialRecord(int IntValue)
-        {
+            public int IntValue { get; init; }
             public string? StringValue { get; init; }
+            public StubBaseType? CovariantTypeValue { get; init; }
+            public StubDerivedType? ContravariantTypeValue { get; init; }
         }
 
-        public record EmptyRecord();
-
-        public class NonRecord
-        {
-            public NonRecord(string stringValue)
-            {
-            }
-
-            public int IntValue { get; set; }
-        }
+        public class StubBaseType { }
+        public class StubDerivedType : StubBaseType { }
     }
 }


### PR DESCRIPTION
Added support to cast context/input values to records.

```CSharp
public class Input
{
  public int A { get; init; }
  public int B { get; init; }
}
```

Can now be written as

```CSharp
public record Input(int A, int B);
```

The original caster would only instantiate objects with an empty constructor.  Updated still only allows one constructor, but will attempt to pull any parameters from the source dictionary (substituting `null` if nothing is found).