### PR TITLE
Added support for freezing behaviors.

### DIFF
--- a/src/DrillSergeant/BehaviorExecutor.cs
+++ b/src/DrillSergeant/BehaviorExecutor.cs
@@ -37,7 +37,7 @@ internal class BehaviorExecutor
             method.Invoke(instance, parameters);
         }
 
-        return BehaviorBuilder.Current;
+        return BehaviorBuilder.Current.Freeze();
     }
 
     public Task Execute(IBehavior behavior, CancellationToken cancellationToken, int timeout = 0)

--- a/src/DrillSergeant/BehaviorFrozenException.cs
+++ b/src/DrillSergeant/BehaviorFrozenException.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
+
+namespace DrillSergeant;
+
+[ExcludeFromCodeCoverage, Serializable]
+public class BehaviorFrozenException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BehaviorFrozenException"/> class.
+    /// </summary>
+    /// <param name="methodName">The name of the method that </param>
+    public BehaviorFrozenException(string methodName)
+        : base($"Cannot modify a behavior once it has been frozen.  The method '{methodName}' was called.")
+    {
+        MethodName = methodName;
+    }
+
+    protected BehaviorFrozenException(SerializationInfo info, StreamingContext context)
+    {
+        MethodName = info.GetString(nameof(MethodName))!;
+    }
+
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        base.GetObjectData(info, context);
+        info.AddValue(nameof(MethodName), MethodName);
+    }
+
+    /// <summary>
+    /// Gets the name of the method that was called that triggered this exception.
+    /// </summary>
+    public string MethodName { get; set; }
+}

--- a/src/DrillSergeant/IBehavior.cs
+++ b/src/DrillSergeant/IBehavior.cs
@@ -27,4 +27,14 @@ public interface IBehavior : IEnumerable<IStep>, IDisposable
     /// Gets a value indicating whether the context should be logged between steps.
     /// </summary>
     bool LogContext { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the behavior has been frozen and unable to be configured further.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Attempting to call any of the configuration methods on a behavior once it has been thrown will result in a <see cref="BehaviorFrozenException"/> exception being thrown.
+    /// </para>
+    /// </remarks>
+    bool IsFrozen { get; }
 }

--- a/test/DrillSergeant.Tests/BehaviorExecutorTests.cs
+++ b/test/DrillSergeant.Tests/BehaviorExecutorTests.cs
@@ -1,4 +1,5 @@
 ﻿using DrillSergeant.Xunit2;
+using FakeItEasy;
 using Shouldly;
 using System;
 using System.Threading;
@@ -13,6 +14,42 @@ public class BehaviorExecutorTests
 {
     public class LoadBehaviorMethod : BehaviorExecutorTests
     {
+        [Fact]
+        public async Task LoadedBehaviorsAreAutomaticallyFrozen()
+        {
+            // Arrange.
+            var reporter = A.Fake<ITestReporter>();
+            var instance = new StubWithBehavior();
+            var method = typeof(StubWithBehavior).GetMethod("SampleBehavior");
+            var parameters = Array.Empty<object?>();
+            var executor = new BehaviorExecutor(reporter);
+
+            // Act.
+            using var behavior = (Behavior)await executor.LoadBehavior(instance, method!, parameters);
+
+            // Assert.
+            behavior.IsFrozen.ShouldBeTrue();
+        }
+        
+        public class StubWithBehavior
+        {
+            public void SampleBehavior()
+            {
+            }
+        }
+
+        public class StubStep : VerbStep {}
+
+        private async Task<Behavior> LoadSampleBehavior()
+        {
+            var reporter = A.Fake<ITestReporter>();
+            var instance = new StubWithBehavior();
+            var method = typeof(StubWithBehavior).GetMethod("SampleBehavior");
+            var parameters = Array.Empty<object?>();
+            var executor = new BehaviorExecutor(reporter);
+
+            return (Behavior)await executor.LoadBehavior(instance, method!, parameters);
+        }
     }
 
     public class ExecuteMethod : BehaviorExecutorTests

--- a/test/DrillSergeant.Tests/BehaviorTests.cs
+++ b/test/DrillSergeant.Tests/BehaviorTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Shouldly;
+﻿using Shouldly;
 using Xunit;
 
 namespace DrillSergeant.Tests;
@@ -98,6 +97,81 @@ public class BehaviorTests
             // Assert.
             behavior.Input.ShouldNotContainKey("A");
         }
+    }
+
+    public class FreezeMethod : BehaviorTests
+    {
+        [Fact]
+        public void AttemptingToAddStepToFrozenBehaviorThrowsBehaviorFrozenException()
+        {
+            // Arrange.
+            using var behavior = new Behavior();
+
+            // Act.
+            behavior.Freeze();
+
+            // Assert.
+            Assert.Throws<BehaviorFrozenException>(
+                () => behavior.AddStep(new StubStep()));
+        }
+
+        [Fact]
+        public void AttemptingToSetInputToFrozenBehaviorThrowsBehaviorFrozenException_Object()
+        {
+            // Arrange.
+            using var behavior = new Behavior();
+
+            // Act.
+            behavior.Freeze();
+
+            // Assert.
+            Assert.Throws<BehaviorFrozenException>(
+                () => behavior.SetInput((object?)null));
+        }
+
+        [Fact]
+        public void AttemptingToSetInputToFrozenBehaviorThrowsBehaviorFrozenException_Dictionary()
+        {
+            // Arrange.
+            using var behavior = new Behavior();
+
+            // Act.
+            behavior.Freeze();
+
+            // Assert.
+            Assert.Throws<BehaviorFrozenException>(
+                () => behavior.SetInput(null));
+        }
+
+        [Fact]
+        public void AttemptingToAddBackgroundToFrozenBehaviorThrowsBehaviorFrozenException()
+        {
+            // Arrange.
+            using var behavior = new Behavior();
+
+            // Act.
+            behavior.Freeze();
+
+            // Assert.
+            Assert.Throws<BehaviorFrozenException>(
+                () => behavior.Background(new Behavior()));
+        }
+
+        [Fact]
+        public void AttemptingToEnableContextLoggingToFrozenBehaviorThrowsBehaviorFrozenException()
+        {
+            // Arrange.
+            using var behavior = new Behavior();
+
+            // Act.
+            behavior.Freeze();
+
+            // Assert.
+            Assert.Throws<BehaviorFrozenException>(
+                () => behavior.EnableContextLogging());
+        }
+
+        private class StubStep : VerbStep { }
     }
 
     public class DisposeMethod : BehaviorTests


### PR DESCRIPTION
Behaviors can now be frozen.  Once frozen any attempt to modify them will throw a `BehaviorFrozenException`.  This is to prevent steps from attempting to modify their own behavior.

By default, `BehaviorExecutor` will automatically freeze any behavior it loads.