### PR TITLE
Add scoping support for behaviors.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "husky": {
+      "version": "0.5.4",
+      "commands": [
+        "husky"
+      ]
+    }
+  }
+}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+## husky task runner examples -------------------
+## Note : for local installation use 'dotnet' prefix. e.g. 'dotnet husky'
+
+## run all tasks
+#husky run
+
+### run all tasks with group: 'group-name'
+#husky run --group group-name
+
+## run task with name: 'task-name'
+#husky run --name task-name
+
+## pass hook arguments to task
+#husky run --args "$1" "$2"
+
+## or put your custom commands -------------------
+#echo 'Husky.Net is awesome!'
+
+dotnet format

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -19,4 +19,4 @@
 ## or put your custom commands -------------------
 #echo 'Husky.Net is awesome!'
 
-dotnet format
+dotnet husky run --group pre-commit

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,13 @@
+{
+   "tasks": [
+      {
+         "name": "welcome-message-example",
+         "command": "bash",
+         "args": [ "-c", "echo Husky.Net is awesome!" ],
+         "windows": {
+            "command": "cmd",
+            "args": ["/c", "echo Husky.Net is awesome!" ]
+         }
+      }
+   ]
+}

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,13 +1,11 @@
 {
    "tasks": [
       {
-         "name": "welcome-message-example",
-         "command": "bash",
-         "args": [ "-c", "echo Husky.Net is awesome!" ],
-         "windows": {
-            "command": "cmd",
-            "args": ["/c", "echo Husky.Net is awesome!" ]
-         }
+         "name": "dotnet-format",
+         "group": "pre-commit",
+         "command": "dotnet",
+         "args": ["dotnet-format", "--include", "${staged}"],
+         "include": ["**/*.cs"]
       }
    ]
 }

--- a/src/DrillSergeant/Behavior.cs
+++ b/src/DrillSergeant/Behavior.cs
@@ -217,9 +217,9 @@ public class Behavior : IBehavior
         _disposed = true;
     }
 
-    private void AssertNotFrozen([CallerMemberName]string memberName="")
+    private void AssertNotFrozen([CallerMemberName] string memberName = "")
     {
-        if(_isFrozen)
+        if (_isFrozen)
         {
             throw new BehaviorFrozenException(memberName);
         }

--- a/src/DrillSergeant/Behavior.cs
+++ b/src/DrillSergeant/Behavior.cs
@@ -1,17 +1,18 @@
-﻿using System;
+﻿using JetBrains.Annotations;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using JetBrains.Annotations;
 
 namespace DrillSergeant;
 
 /// <summary>
 /// Defines a behavior, encapsulating a series of steps to run as a single test.
 /// </summary>
+// ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
 public class Behavior : IBehavior
 {
     private readonly List<IStep> _steps = new();
@@ -22,7 +23,7 @@ public class Behavior : IBehavior
     /// <summary>
     /// Initializes a new instance of the <see cref="Behavior"/> class.
     /// </summary>
-    public Behavior()
+    internal Behavior()
         : this(new { })
     {
     }
@@ -31,7 +32,7 @@ public class Behavior : IBehavior
     /// Initializes a new instance of the <see cref="Behavior"/> class.
     /// </summary>
     /// <param name="input">The input to bind to the behavior.</param>
-    public Behavior(object? input) =>
+    internal Behavior(object? input) =>
         SetInput(input);
 
     /// <summary>

--- a/src/DrillSergeant/Behavior.cs
+++ b/src/DrillSergeant/Behavior.cs
@@ -49,7 +49,14 @@ public class Behavior : IBehavior
     /// <inheritdoc cref="IBehavior.LogContext" />
     public bool LogContext { get; private set; }
 
-    /// <inheritdoc cref="IBehavior.IsFrozen" />
+    /// <summary>
+    /// Gets a value indicating whether the behavior has been frozen and unable to be configured further.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Attempting to call any of the configuration methods on a behavior once it has been thrown will result in a <see cref="BehaviorFrozenException"/> exception being thrown.
+    /// </para>
+    /// </remarks>
     public bool IsFrozen => _isFrozen;
 
     internal ISet<IDisposable> OwnedDisposables => _ownedDisposables;

--- a/src/DrillSergeant/BehaviorBuilder.cs
+++ b/src/DrillSergeant/BehaviorBuilder.cs
@@ -82,6 +82,15 @@ public static class BehaviorBuilder
         }
     }
 
-    internal static Stack<Behavior> GetCurrentStack() =>
-        CurrentStack.Value ?? (CurrentStack.Value = new());
+    internal static Stack<Behavior> GetCurrentStack()
+    {
+        Stack<Behavior>? value = CurrentStack.Value;
+
+        if (value != null)
+        {
+            return value;
+        }
+
+        return CurrentStack.Value = new();
+    }
 }

--- a/src/DrillSergeant/BehaviorBuilder.cs
+++ b/src/DrillSergeant/BehaviorBuilder.cs
@@ -76,20 +76,10 @@ public static class BehaviorBuilder
         return behavior;
     }
 
-    internal static async Task PushAsync(Behavior behavior, Func<Task> action)
+    internal static IDisposable Push(Behavior behavior)
     {
-        var stack = GetCurrentStack();
-
-        stack.Push(behavior);
-
-        try
-        {
-            await action();
-        }
-        finally
-        {
-            stack.Pop();
-        }
+        GetCurrentStack()?.Push(behavior);
+        return new StackCleanup();
     }
 
     internal static Stack<Behavior> GetCurrentStack()
@@ -102,5 +92,10 @@ public static class BehaviorBuilder
         }
 
         return CurrentStack.Value = new();
+    }
+
+    private class StackCleanup : IDisposable
+    {
+        public void Dispose() => CurrentStack.Value?.Pop();
     }
 }

--- a/src/DrillSergeant/BehaviorBuilder.cs
+++ b/src/DrillSergeant/BehaviorBuilder.cs
@@ -28,6 +28,11 @@ public static class BehaviorBuilder
         }
     }
 
+    /// <summary>
+    /// Builds a new behavior.
+    /// </summary>
+    /// <param name="configure">The callback to execute to configure the behavior.</param>
+    /// <returns>The configured behavior.</returns>
     public static Behavior Build(Action<Behavior> configure)
     {
         var behavior = new Behavior();
@@ -47,6 +52,11 @@ public static class BehaviorBuilder
         return behavior;
     }
 
+    /// <summary>
+    /// Builds a new behavior asynchronously.
+    /// </summary>
+    /// <param name="configure">The callback to execute to configure the behavior.</param>
+    /// <returns>The configured behavior.</returns>
     public static async Task<Behavior> BuildAsync(Func<Behavior, Task<Behavior>> configure)
     {
         var behavior = new Behavior();

--- a/src/DrillSergeant/BehaviorBuilder.cs
+++ b/src/DrillSergeant/BehaviorBuilder.cs
@@ -19,7 +19,7 @@ public static class BehaviorBuilder
         {
             var stack = GetCurrentStack();
 
-            if(stack.Any())
+            if (stack.Any())
             {
                 return stack.Peek();
             }
@@ -32,7 +32,7 @@ public static class BehaviorBuilder
     {
         var behavior = new Behavior();
         var stack = GetCurrentStack();
-        
+
         stack.Push(behavior);
 
         try
@@ -82,6 +82,6 @@ public static class BehaviorBuilder
         }
     }
 
-    internal static Stack<Behavior> GetCurrentStack() => 
+    internal static Stack<Behavior> GetCurrentStack() =>
         CurrentStack.Value ?? (CurrentStack.Value = new());
 }

--- a/src/DrillSergeant/BehaviorBuilder.cs
+++ b/src/DrillSergeant/BehaviorBuilder.cs
@@ -1,39 +1,87 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace DrillSergeant;
 
 public static class BehaviorBuilder
 {
-    private static readonly AsyncLocal<Behavior?> Instance = new();
+    private static readonly AsyncLocal<Stack<Behavior>> CurrentStack = new();
 
     /// <summary>
     /// Gets the current behavior to test.
     /// </summary>
-    public static Behavior Current => Instance.Value ?? new Behavior();
-
-    /// <summary>
-    /// Creates a new behavior to build.
-    /// </summary>
-    /// <param name="input">The input parameters for the behavior.</param>
-    /// <returns>The new behavior to build.</returns>
-    internal static Behavior Reset(object? input = null)
+    public static Behavior Current
     {
-        Instance.Value?.Dispose();
-        Instance.Value = new Behavior().SetInput(input);
+        get
+        {
+            var stack = GetCurrentStack();
 
-        return Instance.Value;
+            if(stack.Any())
+            {
+                return stack.Peek();
+            }
+
+            throw new NoCurrentBehaviorException();
+        }
     }
 
-    /// <summary>
-    /// Resets the current behavior builder.
-    /// </summary>
-    /// <param name="input">The dictionary to use for input data.</param>
-    internal static Behavior Reset(IDictionary<string, object?> input)
+    public static Behavior Build(Action<Behavior> configure)
     {
-        Instance.Value?.Dispose();
-        Instance.Value = new Behavior().SetInput(input);
+        var behavior = new Behavior();
+        var stack = GetCurrentStack();
+        
+        stack.Push(behavior);
 
-        return Instance.Value;
+        try
+        {
+            configure?.Invoke(behavior);
+        }
+        finally
+        {
+            stack.Pop();
+        }
+
+        return behavior;
     }
+
+    public static async Task<Behavior> BuildAsync(Func<Behavior, Task<Behavior>> configure)
+    {
+        var behavior = new Behavior();
+        var stack = GetCurrentStack();
+
+        stack.Push(behavior);
+
+        try
+        {
+            await configure(behavior);
+        }
+        finally
+        {
+            stack.Pop();
+        }
+
+        return behavior;
+    }
+
+    internal static async Task PushAsync(Behavior behavior, Func<Task> action)
+    {
+        var stack = GetCurrentStack();
+
+        stack.Push(behavior);
+
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            stack.Pop();
+        }
+    }
+
+    internal static Stack<Behavior> GetCurrentStack() => 
+        CurrentStack.Value ?? (CurrentStack.Value = new());
 }

--- a/src/DrillSergeant/BehaviorExecutor.cs
+++ b/src/DrillSergeant/BehaviorExecutor.cs
@@ -43,11 +43,15 @@ internal class BehaviorExecutor
         });
     }
 
-    public Task Execute(Behavior behavior, CancellationToken cancellationToken, int timeout = 0) =>
-        BehaviorBuilder.PushAsync(behavior, () =>
-            timeout == 0 ?
+    public Task Execute(Behavior behavior, CancellationToken cancellationToken, int timeout = 0)
+    {
+        using(BehaviorBuilder.Push(behavior))
+        {
+            return timeout == 0 ?
                 ExecuteInternalNoTimeout(behavior, cancellationToken) :
-                ExecuteInternalWithTimeout(behavior, timeout, cancellationToken));
+                ExecuteInternalWithTimeout(behavior, timeout, cancellationToken);
+        }
+    }
 
     private async Task ExecuteInternalWithTimeout(IBehavior behavior, int timeout, CancellationToken cancellationToken)
     {

--- a/src/DrillSergeant/BehaviorExecutor.cs
+++ b/src/DrillSergeant/BehaviorExecutor.cs
@@ -45,7 +45,7 @@ internal class BehaviorExecutor
 
     public Task Execute(Behavior behavior, CancellationToken cancellationToken, int timeout = 0)
     {
-        using(BehaviorBuilder.Push(behavior))
+        using (BehaviorBuilder.Push(behavior))
         {
             return timeout == 0 ?
                 ExecuteInternalNoTimeout(behavior, cancellationToken) :

--- a/src/DrillSergeant/BehaviorExecutor.cs
+++ b/src/DrillSergeant/BehaviorExecutor.cs
@@ -15,7 +15,7 @@ internal class BehaviorExecutor
 
     public BehaviorExecutor(ITestReporter reporter) => _reporter = reporter;
 
-    public async Task<IBehavior> LoadBehavior(object instance, MethodInfo method, object?[] parameters)
+    public async Task<Behavior> LoadBehavior(object instance, MethodInfo method, object?[] parameters)
     {
         var input = new Dictionary<string, object?>();
         var methodParameters = method.GetParameters();
@@ -25,27 +25,29 @@ internal class BehaviorExecutor
             input[methodParameters[i].Name!] = parameters[i];
         }
 
-        BehaviorBuilder.Reset(input);
-
-        if (IsAsync(method))
+        return await BehaviorBuilder.BuildAsync(async b =>
         {
-            dynamic asyncResult = method.Invoke(instance, parameters)!;
-            await asyncResult;
-        }
-        else
-        {
-            method.Invoke(instance, parameters);
-        }
+            b.SetInput(input);
 
-        return BehaviorBuilder.Current.Freeze();
+            if (IsAsync(method))
+            {
+                dynamic asyncResult = method.Invoke(instance, parameters)!;
+                await asyncResult;
+            }
+            else
+            {
+                method.Invoke(instance, parameters);
+            }
+
+            return b.Freeze();
+        });
     }
 
-    public Task Execute(IBehavior behavior, CancellationToken cancellationToken, int timeout = 0)
-    {
-        return timeout == 0 ?
-            ExecuteInternalNoTimeout(behavior, cancellationToken) :
-            ExecuteInternalWithTimeout(behavior, timeout, cancellationToken);
-    }
+    public Task Execute(Behavior behavior, CancellationToken cancellationToken, int timeout = 0) =>
+        BehaviorBuilder.PushAsync(behavior, () =>
+            timeout == 0 ?
+                ExecuteInternalNoTimeout(behavior, cancellationToken) :
+                ExecuteInternalWithTimeout(behavior, timeout, cancellationToken));
 
     private async Task ExecuteInternalWithTimeout(IBehavior behavior, int timeout, CancellationToken cancellationToken)
     {

--- a/src/DrillSergeant/IBehavior.cs
+++ b/src/DrillSergeant/IBehavior.cs
@@ -27,14 +27,4 @@ public interface IBehavior : IEnumerable<IStep>, IDisposable
     /// Gets a value indicating whether the context should be logged between steps.
     /// </summary>
     bool LogContext { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether the behavior has been frozen and unable to be configured further.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Attempting to call any of the configuration methods on a behavior once it has been thrown will result in a <see cref="BehaviorFrozenException"/> exception being thrown.
-    /// </para>
-    /// </remarks>
-    bool IsFrozen { get; }
 }

--- a/src/DrillSergeant/MissingVerbHandlerException.cs
+++ b/src/DrillSergeant/MissingVerbHandlerException.cs
@@ -8,7 +8,7 @@ namespace DrillSergeant;
 /// Defines an exception that is thrown when no DrillSergeant is unable to find a handler to execute.
 /// </summary>
 [Serializable, ExcludeFromCodeCoverage]
-public class MissingVerbHandlerException : Exception, ISerializable
+public class MissingVerbHandlerException : Exception
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="MissingVerbHandlerException"/> class.

--- a/src/DrillSergeant/NoCurrentBehaviorException.cs
+++ b/src/DrillSergeant/NoCurrentBehaviorException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace DrillSergeant;
+
+[ExcludeFromCodeCoverage]
+public class NoCurrentBehaviorException : Exception
+{
+    public NoCurrentBehaviorException() :
+        base("No current behavior defined.  Accessing the Current behavior can only be done within the scope of a behavior.")
+    {
+    }
+}

--- a/test/DrillSergeant.Tests.MSTest/BehaviorAttributeTests.cs
+++ b/test/DrillSergeant.Tests.MSTest/BehaviorAttributeTests.cs
@@ -94,8 +94,7 @@ public class BehaviorAttributeTests
             [Behavior]
             public void BehaviorThatThrowsException()
             {
-                BehaviorBuilder
-                    .Reset()
+                BehaviorBuilder.Current
                     .AddStep(new LambdaStep().Handle(() => throw new Exception("ERROR")));
             }
         }

--- a/test/DrillSergeant.Tests.Shared/Features/BaseStepFeature.cs
+++ b/test/DrillSergeant.Tests.Shared/Features/BaseStepFeature.cs
@@ -121,19 +121,19 @@ public class BaseStepFeature
             .Skip();
 
     public Behavior SetupContext =>
-        new Behavior()
+        BehaviorBuilder.Build(b => b
             .Given("Background Step 1", c => c.A = 1)
-            .And("Background Step 2", c => c.B = 2);
+            .And("Background Step 2", c => c.B = 2));
 
     public Behavior SetupContextFromInput =>
-        new Behavior()
-            .Given("Setup Context", (c, i) => c.Value = i.Value);
+        BehaviorBuilder.Build(b => b
+            .Given("Setup Context", (c, i) => c.Value = i.Value));
 
     public Behavior SetupContextFromInputAsync =>
-        new Behavior()
+        BehaviorBuilder.Build(b => b
             .GivenAsync("Setup Context", (c, i) =>
             {
                 c.Value = i.Value;
                 return Task.CompletedTask;
-            });
+            }));
 }

--- a/test/DrillSergeant.Tests.Shared/Features/BaseStepFeature.cs
+++ b/test/DrillSergeant.Tests.Shared/Features/BaseStepFeature.cs
@@ -17,7 +17,8 @@ public class BaseStepFeature
             Value = "expected"
         };
 
-        BehaviorBuilder.Reset(input);
+        BehaviorBuilder.Current.SetInput(input);
+
         When("Update input", (c, i) => i.Value = "error");
         Then("Input should be unchanged", (_, i) => ((string)i.Value).ShouldBe("expected"));
     }
@@ -40,7 +41,7 @@ public class BaseStepFeature
     [Behavior]
     public void ConsumingBackgroundAutomaticallyExecutesSteps()
     {
-        BehaviorBuilder.Reset()
+        BehaviorBuilder.Current
             .EnableContextLogging()
             .Background(SetupContext);
 
@@ -56,7 +57,8 @@ public class BaseStepFeature
             Value = "expected"
         };
 
-        BehaviorBuilder.Reset(input)
+        BehaviorBuilder.Current
+            .SetInput(input)
             .EnableContextLogging()
             .Background(SetupContextFromInput);
 
@@ -71,7 +73,8 @@ public class BaseStepFeature
             Value = "expected"
         };
 
-        BehaviorBuilder.Reset(input)
+        BehaviorBuilder.Current
+            .SetInput(input)
             .EnableContextLogging()
             .Background(SetupContextFromInputAsync);
 
@@ -86,7 +89,8 @@ public class BaseStepFeature
             Value = "expected"
         };
 
-        BehaviorBuilder.Reset(input)
+        BehaviorBuilder.Current
+            .SetInput(input)
             .EnableContextLogging()
             .Background(SetupContext);
 

--- a/test/DrillSergeant.Tests/BaseStepTests.cs
+++ b/test/DrillSergeant.Tests/BaseStepTests.cs
@@ -1,9 +1,6 @@
-﻿using Shouldly;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
-using Xunit;
 // ReSharper disable UnusedParameter.Local
 // ReSharper disable UnusedMember.Local
 // ReSharper disable MemberCanBePrivate.Global

--- a/test/DrillSergeant.Tests/BehaviorBuilderTests.cs
+++ b/test/DrillSergeant.Tests/BehaviorBuilderTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace DrillSergeant.Tests;
+
+public class BehaviorBuilderTests
+{
+    public class CurrentProperty : BehaviorBuilderTests
+    {
+        [Fact]
+        public void ThrowsNoCurrentBehaviorExceptionWhenOutsideBuildScope()
+        {
+            // Assert.
+            Assert.Throws<NoCurrentBehaviorException>(() => BehaviorBuilder.Current);
+        }
+    }
+
+    public class BuildMethod : BehaviorBuilderTests
+    {
+        [Fact]
+        public Task StackSizeIsResetAfterSuccessfulBuild()
+        {
+            // Arrange.
+            var stack = BehaviorBuilder.GetCurrentStack();
+            var initialSize = stack.Count;
+
+            // Act.
+            BehaviorBuilder.Build(_ => { });
+
+            // Assert.
+            stack.Count.ShouldBe(initialSize);
+
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public Task StackSizeIsResetWhenExceptionIsThrownDuringBuild()
+        {
+            // Arrange.
+            var stack = BehaviorBuilder.GetCurrentStack();
+            var initialSize = stack.Count;
+
+            // Act.
+            try
+            {
+                BehaviorBuilder.Build(_ => throw new Exception("ignored"));
+            }
+            catch
+            {
+                // Deliberately swallow.
+            }
+
+            // Assert.
+            stack.Count.ShouldBe(initialSize);
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public class BuildAsyncMethod : BehaviorBuilderTests
+    {
+        [Fact]
+        public async Task StackSizeIsResetAfterSuccessfulBuild()
+        {
+            // Arrange.
+            var stack = BehaviorBuilder.GetCurrentStack();
+            var initialSize = stack.Count;
+
+            // Act.
+            await BehaviorBuilder.BuildAsync(Task.FromResult);
+
+            // Assert.
+            stack.Count.ShouldBe(initialSize);
+        }
+
+        [Fact]
+        public async Task StackSizeIsResetWhenExceptionIsThrownDuringBuild()
+        {
+            // Arrange.
+            var stack = BehaviorBuilder.GetCurrentStack();
+            var initialSize = stack.Count;
+
+            // Act.
+            try
+            {
+                await BehaviorBuilder.BuildAsync(_ => throw new Exception("ignored"));
+            }
+            catch
+            {
+                // Deliberately swallow.
+            }
+
+            // Assert.
+            stack.Count.ShouldBe(initialSize);
+        }
+    }
+}

--- a/test/DrillSergeant.Tests/BehaviorExecutorTests.cs
+++ b/test/DrillSergeant.Tests/BehaviorExecutorTests.cs
@@ -125,10 +125,10 @@ public class BehaviorExecutorTests
             var executor = new BehaviorExecutor(_reporter);
 
             var obj = new StubDisposable();
-            var behavior = BehaviorBuilder.Reset()
-                .AddStep(
+            var behavior = BehaviorBuilder.Build(b =>
+                b.AddStep(
                     new LambdaStep("Registers disposable")
-                        .Handle(c => c.Obj = obj.OwnedByBehavior()!));
+                        .Handle(c => c.Obj = obj.OwnedByBehavior()!)));
 
             // Act.
             await executor.Execute(behavior, CancellationToken.None);
@@ -202,19 +202,18 @@ public class BehaviorExecutorTests
         private class StubWithBehaviors
         {
             public Behavior SuccessfulBehavior() =>
-                BehaviorBuilder.Reset()
-                    .AddStep(
-                        new LambdaStep("Successful step")
-                            .Handle(c => c.IsSuccess = true));
+                BehaviorBuilder.Current.AddStep(
+                    new LambdaStep("Successful step")
+                        .Handle(c => c.IsSuccess = true));
 
             public Behavior FailingBehavior() =>
-                BehaviorBuilder.Reset()
+                BehaviorBuilder.Current
                     .AddStep(
                         new LambdaStep("Failing step")
                             .Handle(() => throw new Exception("Failed")));
 
             public Behavior FailingBehaviorWithAdditionalSteps() =>
-                BehaviorBuilder.Reset()
+                BehaviorBuilder.Current
                     .AddStep(
                         new LambdaStep("Set context to true")
                             .Handle(c => c.IsSuccess = true))
@@ -226,7 +225,7 @@ public class BehaviorExecutorTests
                             .Handle(c => c.IsSuccess = false));
 
             public Behavior BehaviorWithSkippedStep() =>
-                BehaviorBuilder.Reset()
+                BehaviorBuilder.Current
                     .AddStep(
                         new LambdaStep("Successful step")
                             .Handle(c => c.IsSuccess = true))
@@ -236,7 +235,7 @@ public class BehaviorExecutorTests
                             .Skip(() => true));
 
             public Behavior BehaviorWithFive100MsSteps() =>
-                BehaviorBuilder.Reset()
+                BehaviorBuilder.Current
                     .AddStep(
                         new LambdaStep("Successful step")
                             .Handle(c => c.IsSuccess = true))

--- a/test/DrillSergeant.Tests/BehaviorExecutorTests.cs
+++ b/test/DrillSergeant.Tests/BehaviorExecutorTests.cs
@@ -1,10 +1,7 @@
 ﻿using DrillSergeant.Xunit2;
-using FakeItEasy;
-using Shouldly;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 

--- a/test/DrillSergeant.Tests/BehaviorExecutorTests.cs
+++ b/test/DrillSergeant.Tests/BehaviorExecutorTests.cs
@@ -27,7 +27,7 @@ public class BehaviorExecutorTests
             // Assert.
             behavior.IsFrozen.ShouldBeTrue();
         }
-        
+
         public class StubWithBehavior
         {
             public void SampleBehavior()
@@ -35,7 +35,7 @@ public class BehaviorExecutorTests
             }
         }
 
-        public class StubStep : VerbStep {}
+        public class StubStep : VerbStep { }
 
         private async Task<Behavior> LoadSampleBehavior()
         {

--- a/test/DrillSergeant.Tests/BehaviorTests.cs
+++ b/test/DrillSergeant.Tests/BehaviorTests.cs
@@ -1,7 +1,4 @@
-﻿using Shouldly;
-using Xunit;
-
-namespace DrillSergeant.Tests;
+﻿namespace DrillSergeant.Tests;
 
 public class BehaviorTests
 {

--- a/test/DrillSergeant.Tests/LambdaStepTests.cs
+++ b/test/DrillSergeant.Tests/LambdaStepTests.cs
@@ -1,7 +1,5 @@
-﻿using Shouldly;
-using System.Dynamic;
+﻿using System.Dynamic;
 using System.Threading.Tasks;
-using Xunit;
 
 namespace DrillSergeant.Tests;
 

--- a/test/DrillSergeant.Tests/ReflectionParameterCasterTests.cs
+++ b/test/DrillSergeant.Tests/ReflectionParameterCasterTests.cs
@@ -1,7 +1,5 @@
-﻿using Shouldly;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using Xunit;
 
 namespace DrillSergeant.Tests;
 

--- a/test/DrillSergeant.Tests/Usings.cs
+++ b/test/DrillSergeant.Tests/Usings.cs
@@ -1,0 +1,3 @@
+﻿global using FakeItEasy;
+global using Shouldly;
+global using Xunit;

--- a/test/DrillSergeant.Tests/VerbStepTests.cs
+++ b/test/DrillSergeant.Tests/VerbStepTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Dynamic;
 using System.Threading.Tasks;
-using Xunit;
 // ReSharper disable UnusedParameter.Global
 // ReSharper disable MemberCanBePrivate.Global
 #pragma warning disable IDE0060


### PR DESCRIPTION
`BehaviorBuilder` now maintains a thread-safe stack of behaviors that have been defined.  When implicit steps are added they are registered with the topmost behavior.

This allows nested behaviors to be defined.

Scopes for new behaviors are created by calling `BehaviorBuilder.Build()`.
Note: This is automatically called by DrillSergeant for behavior tests and is only needed when defining a method/property that needs to return a new behavior.