### PR TITLE
Added support for AsyncStepResult implicit conversion.

### DIFF
--- a/src/DrillSergeant/AsyncStepResult.cs
+++ b/src/DrillSergeant/AsyncStepResult.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace DrillSergeant;
@@ -43,5 +44,27 @@ public class AsyncStepResult<T>
         }
 
         return await _value;
+    }
+
+    public TaskAwaiter<T> GetAwaiter()
+    {
+        return _value != null ?
+            _value!.GetAwaiter() :
+#pragma warning disable CS8604
+            Task.FromResult<T>(default).GetAwaiter();
+#pragma warning restore CS8604
+    }
+
+    /// <summary>
+    /// Converts an async step result to an awaitable task.
+    /// </summary>
+    /// <param name="stepResult">The step result to convert.</param>
+    public static implicit operator Task<T>(AsyncStepResult<T> stepResult)
+    {
+        return stepResult._value != null ? 
+            stepResult._value.Value : 
+#pragma warning disable CS8604
+            Task.FromResult<T>(default);
+#pragma warning restore CS8604
     }
 }

--- a/test/DrillSergeant.Tests.Shared/Features/CalculatorFeature.cs
+++ b/test/DrillSergeant.Tests.Shared/Features/CalculatorFeature.cs
@@ -78,7 +78,7 @@ public class CalculatorFeature
         var calculator = Given("Create calculator", () => new Calculator());
         var result = WhenAsync("Add numbers", () => Task.FromResult(AddNumbers_Simple(a, b, calculator)));
 
-        ThenAsync("Check result", async () => (await result.Resolve()).ShouldBe(expected));
+        ThenAsync("Check result", () => CheckResultAsync(result, expected));
 
         return Task.CompletedTask;
     }
@@ -102,12 +102,23 @@ public class CalculatorFeature
         var calculator = Given("Create calculator", () => new Calculator());
         var result = When("Add numbers", () => AddNumbers_Simple(a, b, calculator));
 
-        Then("Check result", () => result.Resolve().ShouldBe(expected));
+        Then("Check result", () => CheckResult(result, expected));
     }
 
-    private int AddNumbers_Simple(int a, int b, StepResult<Calculator> calculator)
+    private int AddNumbers_Simple(int a, int b, Calculator calculator)
     {
-        return calculator.Resolve().Add(a, b);
+        return calculator.Add(a, b);
+    }
+
+    private void CheckResult(int given, int expected)
+    {
+        given
+            .ShouldBe(expected);
+    }
+
+    private async Task CheckResultAsync(Task<int> given, int expected)
+    {
+        (await given).ShouldBe(expected);
     }
 
     // Step implemented as a normal method.

--- a/test/DrillSergeant.Tests/AsyncStepResultTests.cs
+++ b/test/DrillSergeant.Tests/AsyncStepResultTests.cs
@@ -5,53 +5,98 @@ namespace DrillSergeant.Tests;
 
 public class AsyncStepResultTests
 {
-    [Fact]
-    public Task ValueIsOnlyEvaluatedOnce() => RunInState(isExecuting: true, async () =>
+    public class Converters : AsyncStepResultTests
     {
-        // Arrange.
-        var step = new AsyncStepResult<object>("ignored", () => Task.FromResult(new object()));
-
-        // Act.
-        var value1 = await step.Resolve();
-        var value2 = await step.Resolve();
-
-        // Assert.
-        value1.ShouldBeSameAs(value2);
-    });
-
-
-    [Fact]
-    public Task AttemptingToResolveValueOutsideExecutionThrowsEagerStepResultEvaluationException() =>
-        RunInState(isExecuting: false, async () =>
+        [Fact]
+        public async Task ConversionToTaskCanBeResolved()
         {
             // Arrange.
-            var step = new AsyncStepResult<bool>("ignored", () => Task.FromResult(true));
+            var stepResult = new AsyncStepResult<string>("ignored", () => Task.FromResult("expected"));
+
+            // Act.
+            Task<string> castedResult = stepResult;
+            var result = await castedResult;
 
             // Assert.
-            await Should.ThrowAsync<EagerStepResultEvaluationException>(async () => await step.Resolve());
-        });
-
-    [Fact]
-    public Task AttemptingToResolveWithoutSettingResultThrowsStepResultNotSetException() =>
-        RunInState(isExecuting: true, async () =>
-        {
-            // Arrange.
-            var step = new AsyncStepResult<bool>("ignored");
-
-            // Assert.
-            await Should.ThrowAsync<StepResultNotSetException>(async () => await step.Resolve());
-        });
-
-    private static Task RunInState(bool isExecuting, Func<Task> action)
-    {
-        try
-        {
-            BehaviorExecutor.IsExecuting.Value = isExecuting;
-            return action();
+            result.ShouldBe("expected");
         }
-        finally
+
+        [Fact]
+        public async Task CanAwaitConvertInOneOperation()
         {
-            BehaviorExecutor.IsExecuting.Value = false;
+            // Arrange.
+            var stepResult = new AsyncStepResult<string>("ignored", () => Task.FromResult("expected"));
+
+            // Act.
+            string result = await stepResult;
+
+            // Assert.
+            result.ShouldBe("expected");
+        }
+
+        [Fact]
+        public async Task AwaitingWithoutSettingValueReturnsDefault()
+        {
+            // Arrange.
+            var stepResult = new AsyncStepResult<string>("ignored");
+
+            // Act.
+            string? result = await stepResult;
+
+            // Assert.
+            result.ShouldBeNull();
+        }
+    }
+
+    public class ResolveMethod : AsyncStepResultTests
+    {
+        [Fact]
+        public Task ValueIsOnlyEvaluatedOnce() => RunInState(isExecuting: true, async () =>
+        {
+            // Arrange.
+            var step = new AsyncStepResult<object>("ignored", () => Task.FromResult(new object()));
+
+            // Act.
+            var value1 = await step.Resolve();
+            var value2 = await step.Resolve();
+
+            // Assert.
+            value1.ShouldBeSameAs(value2);
+        });
+
+        [Fact]
+        public Task AttemptingToResolveValueOutsideExecutionThrowsEagerStepResultEvaluationException() =>
+            RunInState(isExecuting: false, async () =>
+            {
+                // Arrange.
+                var step = new AsyncStepResult<bool>("ignored", () => Task.FromResult(true));
+
+                // Assert.
+                await Should.ThrowAsync<EagerStepResultEvaluationException>(async () => await step.Resolve());
+            });
+
+        [Fact]
+        public Task AttemptingToResolveWithoutSettingResultThrowsStepResultNotSetException() =>
+            RunInState(isExecuting: true, async () =>
+            {
+                // Arrange.
+                var step = new AsyncStepResult<bool>("ignored");
+
+                // Assert.
+                await Should.ThrowAsync<StepResultNotSetException>(async () => await step.Resolve());
+            });
+
+        private static Task RunInState(bool isExecuting, Func<Task> action)
+        {
+            try
+            {
+                BehaviorExecutor.IsExecuting.Value = isExecuting;
+                return action();
+            }
+            finally
+            {
+                BehaviorExecutor.IsExecuting.Value = false;
+            }
         }
     }
 }


### PR DESCRIPTION
`AsyncStepResult<T>` can now be implicitly converted to `Task<T>`.

Also added an awaiter for `AsyncStepResult<T>`.