### PR TITLE
PickHandler() is now limited to 0 args.

### DIFF
--- a/src/DrillSergeant/VerbStep.cs
+++ b/src/DrillSergeant/VerbStep.cs
@@ -46,16 +46,13 @@ public class VerbStep : BaseStep
             throw new MissingVerbHandlerException(Verb);
         }
 
-        var highestGroup = allCandidates.First().ToArray();
-        var numAsync = highestGroup.Count(x => x.IsAsync);
-
-        if (highestGroup.Length >= 2 && numAsync != 1)
+        if (allCandidates.Any(x => x.Key > 0))
         {
             throw new AmbiguousVerbHandlerException(Verb);
         }
 
-        // Prefer async.
-        var handler = highestGroup.FirstOrDefault(x => x.IsAsync) ?? highestGroup.First();
+        var candidates = allCandidates.First();
+        var handler = candidates.FirstOrDefault(x => x.IsAsync) ?? candidates.First();
 
         return handler.Method.ToDelegate(handler.Target);
     }


### PR DESCRIPTION
Simplified `VerbStep.PickHandler()` so that it now only accepts methods with 0 arguments.  Attempting to define a handler with arguments will result in an `AmbiguousVerbHandlerException`.