### PR TITLE
Verb is now set when adding normal steps.

### DIFF
--- a/src/DrillSergeant/StepBuilder.cs
+++ b/src/DrillSergeant/StepBuilder.cs
@@ -13,6 +13,7 @@ public static class StepBuilder
     public static void AddStep(string verb, string name, Action handler)
     {
         AddStep(
+            verb,
             new LambdaStep()
                 .SetName(name)
                 .Handle(handler));
@@ -22,6 +23,7 @@ public static class StepBuilder
     public static void AddStepAsync(string verb, string name, Func<Task> handler)
     {
         AddStep(
+            verb,
             new LambdaStep()
                 .SetName(name)
                 .HandleAsync(handler));

--- a/test/DrillSergeant.Tests/StepBuilderTests.cs
+++ b/test/DrillSergeant.Tests/StepBuilderTests.cs
@@ -1,0 +1,139 @@
+﻿namespace DrillSergeant.Tests;
+
+public class StepBuilderTests
+{
+    [Fact]
+    public Task AddingStepWithVerbAndActionSetsVerbOnBehavior()
+    {
+        // Arrange.
+        const string verb = "expected";
+
+        // Act.
+        var behavior = BehaviorBuilder.Build(_ =>
+        {
+            StepBuilder.AddStep(verb, "ignored", () => { });
+        });
+
+        // Assert.
+        behavior.First().Verb.ShouldBe(verb);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task AddingAsyncStepWithVerbAndFuncSetsVerbOnBehavior()
+    {
+        // Arrange.
+        const string verb = "expected";
+
+        // Act.
+        var behavior = BehaviorBuilder.Build(_ =>
+        {
+            StepBuilder.AddStepAsync(verb, "ignored", () => Task.CompletedTask);
+        });
+
+        // Assert.
+        behavior.First().Verb.ShouldBe(verb);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task AddingStepWithVerbAndThatReturnsResultSetsVerbOnBehavior()
+    {
+        // Arrange.
+        const string verb = "expected";
+
+        // Act.
+        var behavior = BehaviorBuilder.Build(_ =>
+        {
+            StepBuilder.AddStep(verb, "ignored", () => "ignored");
+        });
+
+        // Assert.
+        behavior.First().Verb.ShouldBe(verb);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task AddingAsyncStepWithVerbAndThatReturnsResultSetsVerbOnBehavior()
+    {
+        // Arrange.
+        const string verb = "expected";
+
+        // Act.
+        var behavior = BehaviorBuilder.Build(_ =>
+        {
+            StepBuilder.AddStepAsync(verb, "ignored", () => Task.FromResult("ignored"));
+        });
+
+        // Assert.
+        behavior.First().Verb.ShouldBe(verb);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task AddingStepWithVerbAndStepFixtureSetsVerbOnBehavior()
+    {
+        // Arrange.
+        const string verb = "expected";
+        var fixture = A.Fake<StepFixture<object>>(options =>
+        {
+            options.WithArgumentsForConstructor(new[] { "ignored" });
+        });
+
+        // Act.
+        var behavior = BehaviorBuilder.Build(_ =>
+        {
+            StepBuilder.AddStep(verb, fixture);
+        });
+
+        // Assert.
+        behavior.First().Verb.ShouldBe(verb);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task AddingAsyncStepWithVerbAndAsyncStepFixtureSetsVerbOnBehavior()
+    {
+        // Arrange.
+        const string verb = "expected";
+        var fixture = A.Fake<AsyncStepFixture<object>>(options =>
+        {
+            options.WithArgumentsForConstructor(new[] { "ignored" });
+        });
+
+        // Act.
+        var behavior = BehaviorBuilder.Build(_ =>
+        {
+            StepBuilder.AddStepAsync(verb, fixture);
+        });
+
+        // Assert.
+        behavior.First().Verb.ShouldBe(verb);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task AddingStepWithVerbAndStepInstanceSetsVerbOnBehavior()
+    {
+        // Arrange.
+        const string verb = "expected";
+        var step = new LambdaStep();
+
+        // Act.
+        var behavior = BehaviorBuilder.Build(_ =>
+        {
+            StepBuilder.AddStep(verb, step);
+        });
+
+        // Assert.
+        behavior.First().Verb.ShouldBe(verb);
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
When calling the `AddStep()` and `AddStepAsync()` methods, the provided verb was not being fed into the chained called, resulting in the step verb being reported as "<unknown>".

The parameter is passed now to ensure that it is used.  This also shortened the call chain from:
```CSharp
AddStep(string, string, Action) -> AddStep(IStep) -> AddStep(string, IStep)

// to

AddStep(string, string, Action) -> AddStep(string, IStep)
```

