### PR TITLE
Fixed syntax issues.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,11 +1,6 @@
 ﻿name: CICD
 on: 
   push:
-    paths-ignore:
-      - '.github/**'
-      - '**.md'
-      - '**/.*'
-      - LICENSE
   pull_request:
   workflow_dispatch:
   release:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version:
+          dotnet-version: |
             6.0.x
             7.0.x
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,12 +3,8 @@
 on:
   push:
     branches: [ main, dev ]
-    paths-ignore:
-      - '.github/**'
   pull_request:
     branches: [ main, dev ]
-    paths-ignore:
-      - '.github/**'
   schedule:
     - cron: '34 19 * * 2'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
-        with:
-          languages: csharp
-          config-file: .github/codeql-config.yml
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,4 +49,6 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
         with:
-          category: "/language:csharp"
+          languages: csharp
+          config-file: .github/codeql-config.yml
+

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main, dev ]
   pull_request:
-    branches: [ main, dev ]
   schedule:
     - cron: '34 19 * * 2'
 


### PR DESCRIPTION
There was a missing `|` in the `setup-dotnet` version that was causing it to only install dotnet 6 sdk.

Added language and explicitly set configuration file for codeql.

Also updated triggers:
* CICD now fires for all pushes and pull requests.
* CodeQL now fires for pushes to `dev`/`main` and pull requests.