### PR TITLE
Allow input to be mapped to anonymous objects.

### DIFF
--- a/src/DrillSergeant/CurrentBehavior.cs
+++ b/src/DrillSergeant/CurrentBehavior.cs
@@ -102,7 +102,7 @@ public static class CurrentBehavior
 
         var args =
             from property in typeof(T).GetProperties(flags)
-            let input = Instance.Value!.CopiedInput
+            let input = Instance.Value!.CopiedInput!
             let hasProperty = input.ContainsKey(property.Name)
             let hasMatchingType = hasProperty && input[property.Name].GetType() == property.PropertyType
             select hasMatchingType ? input[property.Name] : null;

--- a/src/DrillSergeant/CurrentBehavior.cs
+++ b/src/DrillSergeant/CurrentBehavior.cs
@@ -102,9 +102,9 @@ public static class CurrentBehavior
 
         var args =
             from property in typeof(T).GetProperties(flags)
-            let input = Instance.Value!.CopiedInput!
+            let input = Instance.Value!.CopiedInput
             let hasProperty = input.ContainsKey(property.Name)
-            let hasMatchingType = hasProperty && input[property.Name].GetType() == property.PropertyType
+            let hasMatchingType = hasProperty && input[property.Name]?.GetType() == property.PropertyType
             select hasMatchingType ? input[property.Name] : null;
 
         var result = Activator.CreateInstance(typeof(T), args.ToArray());

--- a/src/DrillSergeant/CurrentBehavior.cs
+++ b/src/DrillSergeant/CurrentBehavior.cs
@@ -1,7 +1,6 @@
 ﻿using System.Dynamic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 using static DrillSergeant.ParameterCaster;
 
 namespace DrillSergeant;
@@ -105,7 +104,8 @@ public static class CurrentBehavior
             from property in typeof(T).GetProperties(flags)
             let input = Instance.Value!.CopiedInput
             let hasProperty = input.ContainsKey(property.Name)
-            select hasProperty ? input[property.Name] : null;
+            let hasMatchingType = hasProperty && input[property.Name].GetType() == property.PropertyType
+            select hasMatchingType ? input[property.Name] : null;
 
         var result = Activator.CreateInstance(typeof(T), args.ToArray());
 

--- a/test/DrillSergeant.Tests/CurrentBehaviorTests.cs
+++ b/test/DrillSergeant.Tests/CurrentBehaviorTests.cs
@@ -173,6 +173,119 @@ public class CurrentBehaviorTests
         }
     }
 
+    public class MapInputMethod : CurrentBehaviorTests
+    {
+        [Fact]
+        public void MappingToDefinedTypeReturnsMappedType()
+        {
+            // Arrange.
+            var input = new Dictionary<string, object?>
+            {
+                ["IntValue"] = 1
+            };
+
+            CurrentBehavior.Set(new Behavior().SetInput(input));
+
+            // Act.
+            var result = CurrentBehavior.MapInput<StubInput>();
+
+            // Assert.
+            result.IntValue.ShouldBe(1);
+        }
+
+        [Fact]
+        public void MappingToDefinedRecordReturnsMappedType()
+        {
+            // Arrange.
+            var input = new Dictionary<string, object?>
+            {
+                ["IntValue"] = 1,
+                ["StringValue"] = "expected"
+            };
+
+            CurrentBehavior.Set(new Behavior().SetInput(input));
+
+            // Act.
+            var result = CurrentBehavior.MapInput<StubRecord>();
+
+            // Assert.
+            result.ShouldNotBeNull();
+            result.IntValue.ShouldBe(1);
+            result.StringValue.ShouldBe("expected");
+        }
+
+        [Fact]
+        public void MappingToDefinedInlineRecordReturnsMappedType()
+        {
+            // Arrange.
+            var input = new Dictionary<string, object?>
+            {
+                ["IntValue"] = 1,
+                ["StringValue"] = "expected"
+            };
+
+            CurrentBehavior.Set(new Behavior().SetInput(input));
+
+            // Act.
+            var result = CurrentBehavior.MapInput<StubRecordWithCtor>();
+
+            // Assert.
+            result.ShouldNotBeNull();
+            result.IntValue.ShouldBe(1);
+            result.StringValue.ShouldBe("expected");
+        }
+
+        [Fact]
+        public void MappingToReferenceReturnsEquivalentReference()
+        {
+            // Arrange.
+            var input = new Dictionary<string, object?>
+            {
+                ["IntValue"] = 1,
+                ["StringValue"] = "expected"
+            };
+
+            CurrentBehavior.Set(new Behavior().SetInput(input));
+
+            // Act.
+            var result = CurrentBehavior.MapInput(new
+            {
+                IntValue = 0,
+                StringValue = string.Empty
+            });
+
+            // Assert.
+            result.ShouldNotBeNull();
+            result.IntValue.ShouldBe(1);
+            result.StringValue.ShouldBe("expected");
+        }
+
+        [Fact]
+        public void MappingToReferenceReturnsIgnoresMissingProperties()
+        {
+            // Arrange.
+            var input = new Dictionary<string, object?>
+            {
+                ["IntValue"] = 1,
+                ["StringValue"] = "expected"
+            };
+
+            CurrentBehavior.Set(new Behavior().SetInput(input));
+
+            // Act.
+            var result = CurrentBehavior.MapInput(new
+            {
+                IntValue = 0,
+                StringValue = string.Empty,
+                UnknownValue = string.Empty
+            });
+
+            // Assert.
+            result.ShouldNotBeNull();
+            result.UnknownValue.ShouldBeNull();
+        }
+    }
+
     public class CopyInputMethod : CurrentBehaviorTests
     {
         [Fact]
@@ -253,9 +366,26 @@ public class CurrentBehaviorTests
     }
 
     // ReSharper disable once ClassNeverInstantiated.Local
+    private record StubRecordWithCtor(int IntValue, string? StringValue);
+
+    // ReSharper disable once ClassNeverInstantiated.Local
+    private record StubRecord()
+    {
+        public int IntValue { get; init; }
+        public string? StringValue { get; init; }
+    }
+
+    // ReSharper disable once ClassNeverInstantiated.Local
     private class StubContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
+        public string? StringValue { get; set; }
+    }
+
+    // ReSharper disable once ClassNeverInstantiated.Local
+    private class StubInput
+    {
+        public int IntValue { get; set; }
         public string? StringValue { get; set; }
     }
 }

--- a/test/DrillSergeant.Tests/CurrentBehaviorTests.cs
+++ b/test/DrillSergeant.Tests/CurrentBehaviorTests.cs
@@ -284,6 +284,30 @@ public class CurrentBehaviorTests
             result.ShouldNotBeNull();
             result.UnknownValue.ShouldBeNull();
         }
+
+        [Fact]
+        public void MappingToReferenceReturnsIgnoresPropertiesWithDifferentTypes()
+        {
+            // Arrange.
+            var input = new Dictionary<string, object?>
+            {
+                ["IntValue"] = 1,
+                ["StringValue"] = 1
+            };
+
+            CurrentBehavior.Set(new Behavior().SetInput(input));
+
+            // Act.
+            var result = CurrentBehavior.MapInput(new
+            {
+                IntValue = 0,
+                StringValue = string.Empty
+            });
+
+            // Assert.
+            result.ShouldNotBeNull();
+            result.StringValue.ShouldBeNull();
+        }
     }
 
     public class CopyInputMethod : CurrentBehaviorTests


### PR DESCRIPTION
Added ability to pass an anonymous object to `CurrentBehavior.MapInput<T>()`.  This allows type-safe mapping without the need  to declare classes or records ahead of time.

```CSharp
public record MyInput(int A, string B);

// ...

// Within step.
var input = CurrentBehavior.MapInput<MyInput>();
```
can now be written as.
```CSharp
var input = CurrentBehavior.MapInput(new {
    A = 0,
    B = string.Empty
});
```