### PR TITLE
Consolidated DotNetReproducibleBuilds

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -45,6 +45,7 @@
         <None Include="$(SolutionDir)README.md" Visible="true" Pack="true" Link="README.md" PackagePath="/"  />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="DotNet.ReproducibleBuilds" />
         <PackageReference Include="GitVersion.MsBuild" />
     </ItemGroup>
 

--- a/src/DrillSergeant.Analyzers/DrillSergeant.Analyzers.csproj
+++ b/src/DrillSergeant.Analyzers/DrillSergeant.Analyzers.csproj
@@ -10,7 +10,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNet.ReproducibleBuilds" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />

--- a/src/DrillSergeant.MSTest/DrillSergeant.MSTest.csproj
+++ b/src/DrillSergeant.MSTest/DrillSergeant.MSTest.csproj
@@ -5,7 +5,6 @@
   </ItemGroup>
   
   <ItemGroup Label="Dependencies">
-    <PackageReference Include="DotNet.ReproducibleBuilds" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>

--- a/src/DrillSergeant.NUnit3/DrillSergeant.NUnit3.csproj
+++ b/src/DrillSergeant.NUnit3/DrillSergeant.NUnit3.csproj
@@ -5,7 +5,6 @@
   </ItemGroup>
   
   <ItemGroup Label="Dependencies">
-    <PackageReference Include="DotNet.ReproducibleBuilds" />
     <PackageReference Include="NUnit" />
   </ItemGroup>
   

--- a/src/DrillSergeant.Xunit2/DrillSergeant.Xunit2.csproj
+++ b/src/DrillSergeant.Xunit2/DrillSergeant.Xunit2.csproj
@@ -6,7 +6,6 @@
   </ItemGroup>
   
   <ItemGroup Label="Dependencies">
-    <PackageReference Include="DotNet.ReproducibleBuilds" />
     <PackageReference Include="xunit.extensibility.execution" />
   </ItemGroup>
   

--- a/src/DrillSergeant/DrillSergeant.csproj
+++ b/src/DrillSergeant/DrillSergeant.csproj
@@ -28,7 +28,6 @@
   
   <ItemGroup Label="Dependencies">
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="DotNet.ReproducibleBuilds" />
   </ItemGroup>
   
   <ItemGroup Label="Project References">


### PR DESCRIPTION
The reference to `DotNet.ReproducibleBuilds` was in each individual `.csproj` file.  Promoted  it to the `Directory.Build.props` file.