### PR TITLE
Bugfix/compiler warnings

### DIFF
--- a/src/DrillSergeant/BehaviorBuilder.cs
+++ b/src/DrillSergeant/BehaviorBuilder.cs
@@ -13,7 +13,7 @@ public static class BehaviorBuilder
         {
             var stack = GetCurrentStack();
 
-            if (stack.Any())
+            if (stack.Count > 0)
             {
                 return stack.Peek();
             }

--- a/src/DrillSergeant/ParameterCaster.cs
+++ b/src/DrillSergeant/ParameterCaster.cs
@@ -74,7 +74,7 @@ internal static class ParameterCaster
         var ctorParameters = ctor.GetParameters();
         var properties = type.GetProperties(flags);
 
-        return properties.Where(p => ctorParameters.Any(x => x.Name == p.Name) == false).ToArray();
+        return properties.Where(p => ctorParameters.Any(x => x.Name == p.Name) == false);
     }
 
     [SuppressMessage("ReSharper", "SuggestBaseTypeForParameter")]

--- a/src/DrillSergeant/VerbStep.cs
+++ b/src/DrillSergeant/VerbStep.cs
@@ -39,7 +39,7 @@ public class VerbStep : BaseStep
                              select g).ToArray();
 
 
-        if (allCandidates.Any() == false)
+        if (allCandidates.Length == 0)
         {
             throw new MissingVerbHandlerException(Verb);
         }


### PR DESCRIPTION
There were several warnings being issued by the compiler.  This would break pack/publish since they are compiled with `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`.